### PR TITLE
hotfix(analytics): restrict umami tracking to production domains

### DIFF
--- a/src/app/(wids)/[locale]/layout.tsx
+++ b/src/app/(wids)/[locale]/layout.tsx
@@ -9,6 +9,7 @@ import { Toaster } from "@/shared/components/ui/sonner";
 import { Footer } from "@/shared/components/footer";
 import { Header } from "@/shared/components/header";
 import { routing } from "@/shared/lib/next-intl/routing";
+import { UMAMI_TRACKED_DOMAINS } from "@/shared/lib/umami/umami-domains";
 import { cn } from "@/shared/utils/cn";
 import { getAppUrl } from "@/shared/utils/get-app-url";
 import "@/shared/styles/globals.css";
@@ -76,6 +77,7 @@ export default async function RootLayout({
           defer
           src="https://analytics.taws.espol.edu.ec/script.js"
           data-website-id="a9968fe2-7cbd-485c-889b-df72651c22d9"
+          data-domains={UMAMI_TRACKED_DOMAINS}
         />
       </head>
       <body>

--- a/src/shared/lib/react-email/conference-attendance-confirmation.tsx
+++ b/src/shared/lib/react-email/conference-attendance-confirmation.tsx
@@ -15,7 +15,7 @@ import {
 } from "react-email";
 import { createTranslator } from "next-intl";
 
-import { CONFERENCE_ATTENDANCE_CONFIRMATION_PIXEL_URL } from "@/shared/lib/umami/umami-email-pixels";
+import { getConferenceAttendanceConfirmationPixelUrl } from "@/shared/lib/umami/umami-email-pixels";
 import type { Locale } from "@/shared/lib/next-intl/types";
 
 type Props = {
@@ -221,7 +221,7 @@ export const ConferenceAttendanceConfirmationEmail = async ({
             </Text>
 
             <Img
-              src={CONFERENCE_ATTENDANCE_CONFIRMATION_PIXEL_URL}
+              src={getConferenceAttendanceConfirmationPixelUrl()}
               alt=""
               width="1"
               height="1"

--- a/src/shared/lib/react-email/conference-registration-confirmation.tsx
+++ b/src/shared/lib/react-email/conference-registration-confirmation.tsx
@@ -15,7 +15,7 @@ import {
 } from "react-email";
 import { createTranslator } from "next-intl";
 
-import { CONFERENCE_REGISTRATION_CONFIRMATION_PIXEL_URL } from "@/shared/lib/umami/umami-email-pixels";
+import { getConferenceRegistrationConfirmationPixelUrl } from "@/shared/lib/umami/umami-email-pixels";
 import type { Locale } from "@/shared/lib/next-intl/types";
 
 type Props = {
@@ -220,7 +220,7 @@ export const ConferenceRegistrationConfirmationEmail = async ({
             </Text>
 
             <Img
-              src={CONFERENCE_REGISTRATION_CONFIRMATION_PIXEL_URL}
+              src={getConferenceRegistrationConfirmationPixelUrl()}
               alt=""
               width="1"
               height="1"

--- a/src/shared/lib/react-email/conference-registration-reminder.tsx
+++ b/src/shared/lib/react-email/conference-registration-reminder.tsx
@@ -15,7 +15,7 @@ import {
 } from "react-email";
 import { createTranslator } from "next-intl";
 
-import { CONFERENCE_REGISTRATION_REMINDER_PIXEL_URL } from "@/shared/lib/umami/umami-email-pixels";
+import { getConferenceRegistrationReminderPixelUrl } from "@/shared/lib/umami/umami-email-pixels";
 import type { Locale } from "@/shared/lib/next-intl/types";
 
 type Props = {
@@ -232,7 +232,7 @@ export const ConferenceRegistrationReminderEmail = async ({
             </Text>
 
             <Img
-              src={CONFERENCE_REGISTRATION_REMINDER_PIXEL_URL}
+              src={getConferenceRegistrationReminderPixelUrl()}
               alt=""
               width="1"
               height="1"

--- a/src/shared/lib/react-email/datathon-registration-confirmation.tsx
+++ b/src/shared/lib/react-email/datathon-registration-confirmation.tsx
@@ -15,7 +15,7 @@ import {
 } from "react-email";
 import { createTranslator } from "next-intl";
 
-import { DATATHON_REGISTRATION_CONFIRMATION_PIXEL_URL } from "@/shared/lib/umami/umami-email-pixels";
+import { getDatathonRegistrationConfirmationPixelUrl } from "@/shared/lib/umami/umami-email-pixels";
 import type { Locale } from "@/shared/lib/next-intl/types";
 
 type Props = {
@@ -234,7 +234,7 @@ export const DatathonRegistrationConfirmationEmail = async ({
             </Text>
 
             <Img
-              src={DATATHON_REGISTRATION_CONFIRMATION_PIXEL_URL}
+              src={getDatathonRegistrationConfirmationPixelUrl()}
               alt=""
               width="1"
               height="1"

--- a/src/shared/lib/react-email/datathon-registration-reminder.tsx
+++ b/src/shared/lib/react-email/datathon-registration-reminder.tsx
@@ -15,7 +15,7 @@ import {
 } from "react-email";
 import { createTranslator } from "next-intl";
 
-import { DATATHON_REGISTRATION_REMINDER_PIXEL_URL } from "@/shared/lib/umami/umami-email-pixels";
+import { getDatathonRegistrationReminderPixelUrl } from "@/shared/lib/umami/umami-email-pixels";
 import type { Locale } from "@/shared/lib/next-intl/types";
 
 type Props = {
@@ -246,7 +246,7 @@ export const DatathonRegistrationReminderEmail = async ({
             </Text>
 
             <Img
-              src={DATATHON_REGISTRATION_REMINDER_PIXEL_URL}
+              src={getDatathonRegistrationReminderPixelUrl()}
               alt=""
               width="1"
               height="1"

--- a/src/shared/lib/umami/umami-domains.ts
+++ b/src/shared/lib/umami/umami-domains.ts
@@ -1,0 +1,12 @@
+import { getAppUrl } from "@/shared/utils/get-app-url";
+
+export const UMAMI_TRACKED_HOSTNAMES = [
+  "wids.espol.edu.ec",
+  "www.wids.espol.edu.ec",
+];
+
+export const UMAMI_TRACKED_DOMAINS = UMAMI_TRACKED_HOSTNAMES.join(",");
+
+export function isUmamiTrackingEnabled() {
+  return UMAMI_TRACKED_HOSTNAMES.includes(getAppUrl().hostname);
+}

--- a/src/shared/lib/umami/umami-email-pixels.ts
+++ b/src/shared/lib/umami/umami-email-pixels.ts
@@ -1,14 +1,32 @@
-export const CONFERENCE_REGISTRATION_CONFIRMATION_PIXEL_URL =
-  "https://analytics.taws.espol.edu.ec/p/s4vmt4BFG";
+import { isUmamiTrackingEnabled } from "./umami-domains";
 
-export const CONFERENCE_REGISTRATION_REMINDER_PIXEL_URL =
-  "https://analytics.taws.espol.edu.ec/p/Euv3U53YE";
+const UMAMI_PIXEL_BASE_URL = "https://analytics.taws.espol.edu.ec/p";
 
-export const DATATHON_REGISTRATION_CONFIRMATION_PIXEL_URL =
-  "https://analytics.taws.espol.edu.ec/p/7Y6Unu0TK";
+const TRANSPARENT_PIXEL_URL =
+  "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
 
-export const DATATHON_REGISTRATION_REMINDER_PIXEL_URL =
-  "https://analytics.taws.espol.edu.ec/p/vxymZsi2k";
+function getPixelUrl(id: string) {
+  return isUmamiTrackingEnabled()
+    ? `${UMAMI_PIXEL_BASE_URL}/${id}`
+    : TRANSPARENT_PIXEL_URL;
+}
 
-export const CONFERENCE_ATTENDANCE_CONFIRMATION_PIXEL_URL =
-  "https://analytics.taws.espol.edu.ec/p/PkJ4rJLpZ";
+export function getConferenceRegistrationConfirmationPixelUrl() {
+  return getPixelUrl("s4vmt4BFG");
+}
+
+export function getConferenceRegistrationReminderPixelUrl() {
+  return getPixelUrl("Euv3U53YE");
+}
+
+export function getDatathonRegistrationConfirmationPixelUrl() {
+  return getPixelUrl("7Y6Unu0TK");
+}
+
+export function getDatathonRegistrationReminderPixelUrl() {
+  return getPixelUrl("vxymZsi2k");
+}
+
+export function getConferenceAttendanceConfirmationPixelUrl() {
+  return getPixelUrl("PkJ4rJLpZ");
+}


### PR DESCRIPTION
Closes #130

## What changed

Umami now only reports from the production hostnames `wids.espol.edu.ec` and `www.wids.espol.edu.ec`. Local dev and preview deployments stay out of the dashboard.

The hostname list lives once in `src/shared/lib/umami/umami-domains.ts` and feeds both surfaces:

- **Page tracker** — `UMAMI_TRACKED_DOMAINS` is passed as `data-domains` on the `<Script>` tag. Umami's tracker treats it as a hostname allowlist and disables reporting when `location.hostname` is not in it.
- **Email pixels** — `isUmamiTrackingEnabled()` gates `src/shared/lib/umami/umami-email-pixels.ts`. Off-domain, each pixel resolves to an inline 1x1 transparent GIF `data:` URI instead of the analytics URL, so the `<Img>` still renders but no request is made.

The five email templates now call getters rather than importing constants. This is deliberate: `pnpm build` runs `payload migrate` first and the templates are reachable from `payload.config.ts`, so a module-level `process.env` read would be evaluated at build time and baked in. The getter defers it to send time.

## Verification

Bundled the real modules and exercised the gate across hostnames:

| `APP_URL` | tracking | pixel |
| --- | --- | --- |
| `http://localhost:3000` | off | blocked |
| `https://preview-abc.coolify.app` | off | blocked |
| `https://wids.espol.edu.ec` | **on** | real URL |
| `https://www.wids.espol.edu.ec` | **on** | real URL |
| unset | off | blocked |

`tsc --noEmit` and `eslint` are clean on all touched files.

## Deploy note

The email-pixel gate reads `getAppUrl()`, i.e. `COOLIFY_URL` or `APP_URL`. If production sets neither, or sets a value whose hostname is not exactly one of the two above, transactional emails will silently stop reporting. The page tracker is not exposed to this, since the browser supplies the hostname.