### PR TITLE
chore(repo): enforce contribution conventions with templates and commit linting

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Review is requested automatically from the owners listed here.
+# GitHub skips the request when the owner is the pull request author.
+
+* @waldaara

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,71 @@
+name: Bug report
+description: Something is broken or behaves incorrectly
+title: "[Bug]: "
+labels:
+  - bug
+  - needs-triage
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Everything must be in English. Write a short title that states the problem, for example `[Bug]: cedula validation error is not cleared on input change`.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What is happening, and where? Include the affected files or routes if you know them.
+      placeholder: The Umami tracker reports data from every environment, not just production.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: The exact steps someone else can follow to see the problem.
+      value: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+      description: What should happen instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance criteria
+      description: What does "done" look like? One checkbox per verifiable outcome. Required by CONTRIBUTING.md.
+      value: |
+        - [ ]
+        - [ ]
+    validations:
+      required: true
+
+  - type: dropdown
+    id: environment
+    attributes:
+      label: Where does this happen?
+      multiple: true
+      options:
+        - Production
+        - Preview deployment
+        - Local development
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Screenshots, logs, browser and device, or anything else that helps.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Contribution guide
+    url: https://github.com/Taws-Espol/wids-website/blob/main/CONTRIBUTING.md
+    about: Branch naming, commit convention, and the PR flow before you file or open anything.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,46 @@
+name: Feature or change request
+description: Propose new behaviour, an improvement, or a chore
+title: "[Request]: "
+labels:
+  - enhancement
+  - needs-triage
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Everything must be in English. Write a short title that states what is missing, for example `[Request]: allow attendees to update their registration email`.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What is missing or painful today? Describe the problem before the solution.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: What should be built or changed? Mention the areas of the codebase you expect to touch.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance criteria
+      description: What does "done" look like? One checkbox per verifiable outcome. Required by CONTRIBUTING.md.
+      value: |
+        - [ ]
+        - [ ]
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you weighed, and why you did not pick them.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -32,6 +32,6 @@ migrations, or a note that this is safe and self-contained.
 - [ ] Branch is named `type/wids-<issue-number>`
 - [ ] Linked issue above, so it closes on merge
 - [ ] Everything is in English
-- [ ] `npx tsc --noEmit` passes, and `pnpm lint` reports no _new_ errors or warnings
+- [ ] `pnpm lint` and `npx tsc --noEmit` both pass
 - [ ] Preview deployment builds successfully
 - [ ] Acceptance criteria on the linked issue are met

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,37 @@
+<!--
+The PR title becomes the commit message on main, because this repository squash-merges.
+Keep it in Conventional Commits form: type(scope): short description in english
+-->
+
+Closes #
+
+## What changed
+
+<!-- What this PR does, and why this approach. Not a file-by-file list. -->
+
+## How to verify
+
+<!--
+Steps a reviewer can follow themselves. Not a description of testing you already did.
+Include the URL or route to open, what to click, and what should happen.
+-->
+
+1.
+2.
+
+## Risk and rollout
+
+<!--
+Anything that could break, anything environment-dependent, required env vars,
+migrations, or a note that this is safe and self-contained.
+-->
+
+## Checklist
+
+- [ ] Title follows Conventional Commits and matches the work
+- [ ] Branch is named `type/wids-<issue-number>`
+- [ ] Linked issue above, so it closes on merge
+- [ ] Everything is in English
+- [ ] `npx tsc --noEmit` passes, and `pnpm lint` reports no _new_ errors or warnings
+- [ ] Preview deployment builds successfully
+- [ ] Acceptance criteria on the linked issue are met

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,1 @@
+pnpm exec commitlint --edit "$1"

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,4 @@
-pattern='^(feat|fix|hotfix|ops|refactor|perf|docs|style|test|build|ci|chore|revert)/wids-[0-9]+$'
+pattern='^(feat|fix|refactor|perf|docs|style|test|build|ci|chore|revert)/wids-[0-9]+$'
 zero='0000000000000000000000000000000000000000'
 
 # git feeds one line per ref being pushed:

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,28 @@
+pattern='^(feat|fix|hotfix|ops|refactor|perf|docs|style|test|build|ci|chore|revert)/wids-[0-9]+$'
+zero='0000000000000000000000000000000000000000'
+
+# git feeds one line per ref being pushed:
+#   <local ref> <local sha> <remote ref> <remote sha>
+while read -r local_ref local_sha remote_ref remote_sha; do
+  # Branch deletions and tags are not subject to the naming convention.
+  [ "$local_sha" = "$zero" ] && continue
+  case "$local_ref" in
+    refs/heads/*) ;;
+    *) continue ;;
+  esac
+
+  if [ "$remote_ref" = "refs/heads/main" ]; then
+    echo "pre-push: refusing to push directly to main. Open a pull request instead."
+    echo "          See CONTRIBUTING.md."
+    exit 1
+  fi
+
+  branch="${local_ref#refs/heads/}"
+
+  if ! echo "$branch" | grep -Eq "$pattern"; then
+    echo "pre-push: branch name \"$branch\" does not follow the convention."
+    echo "          Expected: type/wids-<issue-number>, for example fix/wids-115."
+    echo "          See CONTRIBUTING.md."
+    exit 1
+  fi
+done

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,25 +6,23 @@ For local setup (dependencies, environment variables, database, seeding, dev ser
 
 ## Types
 
-Every branch name, commit message, and PR title starts with a type. This project uses the [Conventional Commits](https://www.conventionalcommits.org/) set plus two of its own:
+Every branch name, commit message, and PR title starts with a type from the [Conventional Commits](https://www.conventionalcommits.org/) set:
 
 | Type       | Use it for                                                                     |
 | ---------- | ------------------------------------------------------------------------------ |
 | `feat`     | New user-facing behaviour                                                      |
-| `fix`      | A bug fix that follows the normal review and release flow                      |
-| `hotfix`   | A narrow, urgent fix to something already broken in production                 |
-| `ops`      | Deployment, hosting, or environment configuration — Coolify, Docker, env vars  |
+| `fix`      | A bug fix, urgent or not                                                       |
 | `refactor` | Restructuring that does not change behaviour                                   |
 | `perf`     | A change made specifically to improve performance                              |
 | `docs`     | Documentation only                                                             |
 | `style`    | Formatting only, no logic change                                               |
 | `test`     | Adding or correcting tests                                                     |
-| `build`    | Build system or dependency changes                                             |
+| `build`    | Build system, dependencies, deployment, and environment configuration          |
 | `ci`       | CI pipeline and GitHub Actions configuration only                              |
 | `chore`    | Maintenance that fits nothing above, including tooling and agent configuration |
 | `revert`   | Reverting a previous commit                                                    |
 
-`hotfix` and `ops` are not part of the Conventional Commits specification. They are kept because this repository has always used them, and they are accepted by the commit linter.
+The commit linter accepts these and nothing else.
 
 ## Scopes
 
@@ -70,7 +68,7 @@ This is enforced by the `commit-msg` hook, which runs `commitlint` against `comm
 
 Use one of the issue forms — blank issues are disabled. The form marks **Acceptance criteria** as required, so every issue states what "done" looks like.
 
-**Issue titles are plain descriptive English, not Conventional Commits.** An issue describes a _problem_; a commit describes a _change_. The type is a property of the eventual fix, which nobody knows at filing time — the same bug might land as a `fix`, a `refactor`, or a `hotfix`. Type belongs in **labels**, which are filterable; a title prefix is not.
+**Issue titles are plain descriptive English, not Conventional Commits.** An issue describes a _problem_; a commit describes a _change_. The type is a property of the eventual fix, which nobody knows at filing time — the same bug might land as a `fix`, a `refactor`, or a `perf`. Type belongs in **labels**, which are filterable; a title prefix is not.
 
 The forms prefill a `[Bug]:` or `[Request]:` marker, which also keeps issues visually distinct from PRs in the shared number space.
 
@@ -132,6 +130,4 @@ Hooks run through husky:
 
 If a hook blocks something it should not, fix the name or message rather than passing `--no-verify`.
 
-### Known baseline failures
-
-`pnpm lint` currently exits non-zero because of one pre-existing error in `src/shared/components/ui/carousel.tsx` (`setState` called synchronously within an effect), plus a number of unused-variable warnings in generated Payload migrations. Do not treat these as caused by your change — the bar for a PR is **no new** errors or warnings, not a clean exit code, until that baseline is fixed.
+`pnpm lint` and `npx tsc --noEmit` must both pass before you open a PR.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,37 @@
 # Contributing
 
+Everything must be in English — code, commits, PR titles, branch names, issue titles, and descriptions.
+
+For local setup (dependencies, environment variables, database, seeding, dev server), see [README.md](./README.md#local-development-setup).
+
+## Types
+
+Every branch name, commit message, and PR title starts with a type. This project uses the [Conventional Commits](https://www.conventionalcommits.org/) set plus two of its own:
+
+| Type       | Use it for                                                                     |
+| ---------- | ------------------------------------------------------------------------------ |
+| `feat`     | New user-facing behaviour                                                      |
+| `fix`      | A bug fix that follows the normal review and release flow                      |
+| `hotfix`   | A narrow, urgent fix to something already broken in production                 |
+| `ops`      | Deployment, hosting, or environment configuration — Coolify, Docker, env vars  |
+| `refactor` | Restructuring that does not change behaviour                                   |
+| `perf`     | A change made specifically to improve performance                              |
+| `docs`     | Documentation only                                                             |
+| `style`    | Formatting only, no logic change                                               |
+| `test`     | Adding or correcting tests                                                     |
+| `build`    | Build system or dependency changes                                             |
+| `ci`       | CI pipeline and GitHub Actions configuration only                              |
+| `chore`    | Maintenance that fits nothing above, including tooling and agent configuration |
+| `revert`   | Reverting a previous commit                                                    |
+
+`hotfix` and `ops` are not part of the Conventional Commits specification. They are kept because this repository has always used them, and they are accepted by the commit linter.
+
+## Scopes
+
+A scope is optional but strongly preferred, and must be lower-case kebab-case. Use the singular form and stay consistent — `registration`, never `registrations`.
+
+Common scopes: `landing`, `blog`, `registration`, `conference`, `analytics`, `core`, `agents`, `repo`.
+
 ## Branch naming
 
 All branches must follow this pattern:
@@ -8,42 +40,98 @@ All branches must follow this pattern:
 type/wids-<issue-number>
 ```
 
-The `wids-` prefix is always required. Valid types are the same as Conventional Commits types: `fix`, `feat`, `refactor`, `docs`, `chore`, `test`, etc.
+The `wids-` prefix is always required, and the type must come from the table above.
 
 Examples:
+
 - `fix/wids-115`
 - `feat/wids-103`
 - `docs/wids-121`
 
+This is enforced by the `pre-push` hook, which also refuses direct pushes to `main`.
+
 ## Commit convention
 
-All commits must follow [Conventional Commits](https://www.conventionalcommits.org/):
-
 ```
-type: short description in english
+type(scope): short description in english
 ```
 
-Everything must be in English — code, commits, PR titles, branch names, and descriptions.
-
-To link a commit to its issue and automatically close it on merge, add `fixes #<issue-number>` in the commit body:
+To link a commit to its issue and close it automatically on merge, add `fixes #<issue-number>` in the commit body:
 
 ```
-fix: clear cedula validation error state on input change
+fix(registration): clear cedula validation error state on input change
 
 fixes #115
 ```
 
+This is enforced by the `commit-msg` hook, which runs `commitlint` against `commitlint.config.mjs`.
+
 ## Opening issues
 
-Every issue body must include an `## Acceptance criteria` section describing what "done" looks like.
+Use one of the issue forms — blank issues are disabled. The form marks **Acceptance criteria** as required, so every issue states what "done" looks like.
+
+**Issue titles are plain descriptive English, not Conventional Commits.** An issue describes a _problem_; a commit describes a _change_. The type is a property of the eventual fix, which nobody knows at filing time — the same bug might land as a `fix`, a `refactor`, or a `hotfix`. Type belongs in **labels**, which are filterable; a title prefix is not.
+
+The forms prefill a `[Bug]:` or `[Request]:` marker, which also keeps issues visually distinct from PRs in the shared number space.
+
+```
+Good:  [Bug]: umami reports data from non-production environments
+Bad:   fix(analytics): umami reports data from non-production environments
+```
+
+Labels carry the classification: `bug` or `enhancement` for the kind, and the triage labels below for the state.
+
+### Triage labels
+
+| Label             | Meaning                                  |
+| ----------------- | ---------------------------------------- |
+| `needs-triage`    | Maintainer needs to evaluate this issue  |
+| `needs-info`      | Waiting on reporter for more information |
+| `ready-for-agent` | Fully specified, ready for an AFK agent  |
+| `ready-for-human` | Requires human implementation            |
+| `wontfix`         | Will not be actioned                     |
+
+New issues get `needs-triage` automatically from the form. These strings are mirrored in `docs/agents/triage-labels.md`, which the agent skills read — change both together.
 
 ## PR flow
 
 1. Create a branch from `main` following the naming convention above
 2. Work and commit following the commit convention above
-3. Push the branch and open a PR
-4. Assign `waldaara` as reviewer — only `waldaara` has bypass permissions to merge into `main`
+3. Push the branch and open a PR, filling in the PR template
+4. Review happens in one of two ways, depending on who opened the PR
+
+**The PR title becomes the commit message on `main`,** because `main` requires linear history and PRs are squash-merged. A sloppy PR title becomes a sloppy commit in history. The `commit-msg` hook cannot catch this — the squash commit is created by GitHub, not locally — so the title is your responsibility.
+
+### Review
+
+`.github/CODEOWNERS` requests review from `waldaara` automatically.
+
+- **If someone other than `waldaara` opened the PR**, wait for `waldaara`'s approval. Only `waldaara` has bypass permissions on `main`.
+- **If `waldaara` opened the PR**, GitHub will not request review from the author, and self-approval is rejected. The mandatory Copilot code review stands in, and `waldaara` merges using their bypass permission.
+
+### Branch protection on `main`
+
+Two rulesets are active and will block a merge that does not satisfy them:
+
+- Pull request required, linear history required, no force pushes, no deletion
+- Copilot code review required
 
 ## CI/CD
 
 Every PR gets a preview deployment automatically. If the build fails, the PR will not be reviewed — fix the build first.
+
+## Local enforcement
+
+Hooks run through husky:
+
+| Hook         | What it does                                                 |
+| ------------ | ------------------------------------------------------------ |
+| `pre-commit` | Runs `lint-staged` — eslint and prettier on staged files     |
+| `commit-msg` | Runs `commitlint` on the commit message                      |
+| `pre-push`   | Validates the branch name and blocks direct pushes to `main` |
+
+If a hook blocks something it should not, fix the name or message rather than passing `--no-verify`.
+
+### Known baseline failures
+
+`pnpm lint` currently exits non-zero because of one pre-existing error in `src/shared/components/ui/carousel.tsx` (`setState` called synchronously within an effect), plus a number of unused-variable warnings in generated Payload migrations. Do not treat these as caused by your change — the bar for a PR is **no new** errors or warnings, not a clean exit code, until that baseline is fixed.

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -2,27 +2,6 @@
 export default {
   extends: ["@commitlint/config-conventional"],
   rules: {
-    // Adds the two project-specific types this repo actually uses on top of the
-    // Conventional Commits set. See CONTRIBUTING.md for when each one applies.
-    "type-enum": [
-      2,
-      "always",
-      [
-        "feat",
-        "fix",
-        "hotfix",
-        "ops",
-        "refactor",
-        "perf",
-        "docs",
-        "style",
-        "test",
-        "build",
-        "ci",
-        "chore",
-        "revert",
-      ],
-    ],
     // Scopes are optional and free-form, but must be lower-case kebab-case so
     // that "registration" and "Registrations" cannot both appear in history.
     "scope-case": [2, "always", "kebab-case"],

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,0 +1,30 @@
+/** @type {import("@commitlint/types").UserConfig} */
+export default {
+  extends: ["@commitlint/config-conventional"],
+  rules: {
+    // Adds the two project-specific types this repo actually uses on top of the
+    // Conventional Commits set. See CONTRIBUTING.md for when each one applies.
+    "type-enum": [
+      2,
+      "always",
+      [
+        "feat",
+        "fix",
+        "hotfix",
+        "ops",
+        "refactor",
+        "perf",
+        "docs",
+        "style",
+        "test",
+        "build",
+        "ci",
+        "chore",
+        "revert",
+      ],
+    ],
+    // Scopes are optional and free-form, but must be lower-case kebab-case so
+    // that "registration" and "Registrations" cannot both appear in history.
+    "scope-case": [2, "always", "kebab-case"],
+  },
+};

--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@commitlint/cli": "^21.2.1",
+    "@commitlint/config-conventional": "^21.2.0",
     "@react-email/ui": "^6.9.1",
     "@tailwindcss/postcss": "^4.3.3",
     "@types/node": "^26.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,12 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@commitlint/cli':
+        specifier: ^21.2.1
+        version: 21.2.1(@types/node@26.1.1)(conventional-commits-parser@7.1.0)(typescript@6.0.3)
+      '@commitlint/config-conventional':
+        specifier: ^21.2.0
+        version: 21.2.0
       '@react-email/ui':
         specifier: ^6.9.1
         version: 6.9.1(@babel/core@7.29.7)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4)
@@ -405,6 +411,91 @@ packages:
 
   '@borewit/text-codec@0.2.2':
     resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
+
+  '@commitlint/cli@21.2.1':
+    resolution: {integrity: sha512-blsZGe29hJ72VGEFVl72IVYX+1vsfINpjA9yWQA6i7OKD/McGEOXg08sKIRKjFk4JvzhV/9n0l3i6NooPLTNfg==}
+    engines: {node: '>=22.12.0'}
+    hasBin: true
+
+  '@commitlint/config-conventional@21.2.0':
+    resolution: {integrity: sha512-Qf8WRDVcyVd14if6VTWenebxFbKnVnbzPUJjlzjkyJGeHK2xCGd63Dr1XZzj0plXKQb9P0BfOxoc1HVeCo2BWQ==}
+    engines: {node: '>=22.12.0'}
+
+  '@commitlint/config-validator@21.2.0':
+    resolution: {integrity: sha512-t7AzNHAKeIdo/3NRGwzpufKHsKkPHmFs/56N2Fnsh0/r0rGtnQzTxk6vnFgjaGr4hdSQKNB50/KAhR9Yk4LJKA==}
+    engines: {node: '>=22.12.0'}
+
+  '@commitlint/ensure@21.2.0':
+    resolution: {integrity: sha512-76IF9vDNS13lAzEEik9eKwzt8f9hYhWiwVXZ2AnyLCz5/f511FsEQ3pw1X3/zSQpdRLQU7i5qDMVKyXi1GWjSg==}
+    engines: {node: '>=22.12.0'}
+
+  '@commitlint/execute-rule@21.0.1':
+    resolution: {integrity: sha512-RifH+FmImozKBE6mozhF4K3r2RRKP7SMi/Q/zLCmExtp5e05lhHOUYqGBlFBAGNHaZxU/WYw1XuugYK9jQzqnA==}
+    engines: {node: '>=22.12.0'}
+
+  '@commitlint/format@21.2.0':
+    resolution: {integrity: sha512-c4q64xaav2U83t7k7RyzJerBZurPer7FxUOY0RL5L/6CZijZ7K+s6HIBGIghj0ey1P2+seRX0J9XQYtDued6tg==}
+    engines: {node: '>=22.12.0'}
+
+  '@commitlint/is-ignored@21.2.0':
+    resolution: {integrity: sha512-4/eB0vBN7L88O/oC4ajAEqi7j2ZfNgxl/+11RfAV9YosejZgDXhY2C9VcHnHJhOzPLoSy5P3Mg/46kqeyJfXKw==}
+    engines: {node: '>=22.12.0'}
+
+  '@commitlint/lint@21.2.0':
+    resolution: {integrity: sha512-ceO5dp9pLjEZ6y6qbq/uXWXDPykqqlTsyzoQ0NzecpisSJhK3kTy9qzQoPeJuWG/IMNdV1lO0RgmzqoAlSi1uw==}
+    engines: {node: '>=22.12.0'}
+
+  '@commitlint/load@21.2.0':
+    resolution: {integrity: sha512-RjlzWQqruRwIenJEfZtq7kG97co97nKoHpflE5YnF61tDLXxHPrdWImgzw6VL6MlFyaOcVlk74eBV8ZQmc3oIA==}
+    engines: {node: '>=22.12.0'}
+
+  '@commitlint/message@21.2.0':
+    resolution: {integrity: sha512-YxGoiXD/HXNXLJPrQwE5poXa+XH0CBEm+mdvbHQP0g6MV/dmJyUFCzPNzZbxL93GvZ70TmtTK0Z0/IBpAqHv8g==}
+    engines: {node: '>=22.12.0'}
+
+  '@commitlint/parse@21.2.0':
+    resolution: {integrity: sha512-QHWxG4d0PLTF634/AdyZ0MQS+CLn5YOuJlCFhMMlSGKFxzYGUetkHBj18xgBD+6fVzUrA2lrCdi/vlS2f/oYXg==}
+    engines: {node: '>=22.12.0'}
+
+  '@commitlint/read@21.2.1':
+    resolution: {integrity: sha512-hUW7EJQnNTL0vPOmVMNK4CrnrNBN0nN+JJHReFkdHO5y4iyHeEmTBwuC15OCqUTjxWo7idnH1LftfpWVIaPWIA==}
+    engines: {node: '>=22.12.0'}
+
+  '@commitlint/resolve-extends@21.2.0':
+    resolution: {integrity: sha512-4O/1j51+79Wth9s/MGxt/5gs0XYLDgNlYpltQfhAvLE0itusLKs9zruxbiNg1oOkmkb9L9L4USYGjEj7n87NxA==}
+    engines: {node: '>=22.12.0'}
+
+  '@commitlint/rules@21.2.0':
+    resolution: {integrity: sha512-C2yXMNpiB8ETZKfx5JD8+ExgF8vTU1VQMKPSUUYwqKpw9oJWQBrlXBpdU038mj2WPjof7o9UzFpmTyBeGMZwZg==}
+    engines: {node: '>=22.12.0'}
+
+  '@commitlint/to-lines@21.0.1':
+    resolution: {integrity: sha512-bd1BFII7p1EQZre9Kaj+kKaMFP3cFCdt21K7DItVux9XP5WjLgJ0/Uy1pJJh9aPwVJ6SKg62PxqlZaHI8hQAXw==}
+    engines: {node: '>=22.12.0'}
+
+  '@commitlint/top-level@21.2.0':
+    resolution: {integrity: sha512-Y5gmQ+KxzqCrBFJfLvFEPvvwD3LDiNZoTT2yeFBm96M8qhmqSzQc5DvX3rheAaAMjyIvMXOCLS/mWfdpONsjyQ==}
+    engines: {node: '>=22.12.0'}
+
+  '@commitlint/types@21.2.0':
+    resolution: {integrity: sha512-7zVFCDB2reMvJH5dmbKnOQPjZEvjdJTH8jc0U/PIPU1r3/+vf5pD1HlfitV2MWsWXrvu7u39iY1lyLUPOaN0Gw==}
+    engines: {node: '>=22.12.0'}
+
+  '@conventional-changelog/git-client@3.1.0':
+    resolution: {integrity: sha512-Tqa/gHco2WJWa740NRjOrfKVvzIqxkZpecb8bemaQ8sKM5PXb1UK4uTyTb/1wIqNuOVaDOFxyBdhTIQZn6gdjQ==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      conventional-commits-filter: ^6.0.1
+      conventional-commits-parser: ^7.0.1
+    peerDependenciesMeta:
+      conventional-commits-filter:
+        optional: true
+      conventional-commits-parser:
+        optional: true
+
+  '@conventional-changelog/template@1.2.1':
+    resolution: {integrity: sha512-TzlTVpKPjaqW6qOYjQcYUDuGsLCNsvFHVBXkYGTAnf5V37jCWrE5haKNXzz0WZUtVHjrpV76L1buANjwXMfT8w==}
+    engines: {node: '>=22'}
 
   '@date-fns/tz@1.2.0':
     resolution: {integrity: sha512-LBrd7MiJZ9McsOgxqWX7AaxrDjcFVjWH/tIKJd7pnR7McaslGYOP1QmmiBXdJH/H/yLCT+rcQ7FaPBUxRGUtrg==}
@@ -1990,6 +2081,14 @@ packages:
   '@selderee/plugin-htmlparser2@0.11.0':
     resolution: {integrity: sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==}
 
+  '@simple-libs/child-process-utils@2.0.0':
+    resolution: {integrity: sha512-dvNoRKLijXnD0XoJAz94pbNuB5GQgDr55UhpSPhffDkTT0Cmcqh9jSCOtwfT2d4H6MI9E7c4SgtMuJXZ6F3c6A==}
+    engines: {node: '>=22'}
+
+  '@simple-libs/stream-utils@2.0.0':
+    resolution: {integrity: sha512-fCTuZK4QBa+39Oz9l4OGfJfz+GpwCp3AqO7Zch3to99xHPgstVsRFpeQ8LNd2o1Gv8raL2mCFwiaHh7bFSp5DQ==}
+    engines: {node: '>=22'}
+
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
@@ -2547,12 +2646,20 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  argue-cli@3.1.0:
+    resolution: {integrity: sha512-DhBpBfXL4SS2uC0N922MMajKR3CdrTG0u2or1PNYgXMsrSzViJrbtvT0nCLlLGUI0plam/ZZCs7aAauHtW9thw==}
+    engines: {node: '>=22'}
 
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
@@ -2783,6 +2890,10 @@ packages:
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
+  cliui@9.0.1:
+    resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
+    engines: {node: '>=20'}
+
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
@@ -2841,6 +2952,19 @@ packages:
     resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
     engines: {node: '>=18'}
 
+  conventional-changelog-angular@9.2.1:
+    resolution: {integrity: sha512-oWSL6ZhnXbYraOFTK3PgRAQJ8fADDAEv5K6AdeyQPLvjFmhG8+ejL0jZZp/R7vTmGJaBvZEE+sE7dB4bCv7sAw==}
+    engines: {node: '>=22'}
+
+  conventional-changelog-conventionalcommits@10.2.1:
+    resolution: {integrity: sha512-n4Kr1HFMTf3iMbES0TMxKIcYtUUv4rKqyQQp2JwfOEfFCOfGT3Tq4mCyJ8S9/YPyWhydjfKrrvnyl+gCjA+mJQ==}
+    engines: {node: '>=22'}
+
+  conventional-commits-parser@7.1.0:
+    resolution: {integrity: sha512-DPp6hkUjvwIivxbkrTiLXeRswNv1A/4GFA2X6scXma0AMa9632V3TwxmrlkUIEtUktiM3Ln+RrSH2xlP3/jUTw==}
+    engines: {node: '>=22'}
+    hasBin: true
+
   convert-source-map@1.9.0:
     resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
 
@@ -2858,6 +2982,14 @@ packages:
   cors@2.8.6:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
+
+  cosmiconfig-typescript-loader@6.3.0:
+    resolution: {integrity: sha512-Akr82WH1Wfqatyiqpj8HDkO2o2KmJRu1FhKfSNJP3K4IdXwHfEyL7MOb62i1AGQVLtIQM+iCE9CGOtrfhR+mmA==}
+    engines: {node: '>=v18'}
+    peerDependencies:
+      '@types/node': '*'
+      cosmiconfig: '>=9'
+      typescript: '>=5'
 
   cosmiconfig@7.1.0:
     resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
@@ -3274,6 +3406,9 @@ packages:
     resolution: {integrity: sha512-yPDz7wqpg1/mmHLmS3tcfTfbw5f1eryXvyghYBffGdERwe+mV7ZcWzTR8LR17Kvqt3qfPurjlonmnq3MKXIOXw==}
     engines: {node: '>= 0.4'}
 
+  es-toolkit@1.50.0:
+    resolution: {integrity: sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==}
+
   esbuild-register@3.6.0:
     resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
     peerDependencies:
@@ -3608,6 +3743,10 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
   get-east-asian-width@1.6.0:
     resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
     engines: {node: '>=18'}
@@ -3657,6 +3796,10 @@ packages:
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
+
+  global-directory@5.0.0:
+    resolution: {integrity: sha512-1pgFdhK3J2LeM+dVf2Pd424yHx2ou338lC0ErNP2hPx4j8eW1Sp0XqSjNxtk6Tc4Kr5wlWtSvz8cn2yb7/SG/w==}
+    engines: {node: '>=20'}
 
   global-modules@1.0.0:
     resolution: {integrity: sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==}
@@ -3825,6 +3968,10 @@ packages:
 
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
+  ini@6.0.0:
+    resolution: {integrity: sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
@@ -5123,6 +5270,10 @@ packages:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
 
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
@@ -5763,6 +5914,10 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  wrap-ansi@9.0.2:
+    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
+    engines: {node: '>=18'}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -5791,6 +5946,10 @@ packages:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
 
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
@@ -5802,6 +5961,14 @@ packages:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
+
+  yargs-parser@22.0.0:
+    resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
+  yargs@18.0.0:
+    resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
 
   yjs@13.6.30:
     resolution: {integrity: sha512-vv/9h42eCMC81ZHDFswuu/MKzkl/vyq1BhaNGfHyOonwlG4CJbQF4oiBBJPvfdeCt/PlVDWh7Nov9D34YY09uQ==}
@@ -6263,6 +6430,125 @@ snapshots:
       '@types/react': 19.2.17
 
   '@borewit/text-codec@0.2.2': {}
+
+  '@commitlint/cli@21.2.1(@types/node@26.1.1)(conventional-commits-parser@7.1.0)(typescript@6.0.3)':
+    dependencies:
+      '@commitlint/config-conventional': 21.2.0
+      '@commitlint/format': 21.2.0
+      '@commitlint/lint': 21.2.0
+      '@commitlint/load': 21.2.0(@types/node@26.1.1)(typescript@6.0.3)
+      '@commitlint/read': 21.2.1(conventional-commits-parser@7.1.0)
+      '@commitlint/types': 21.2.0
+      tinyexec: 1.2.4
+      yargs: 18.0.0
+    transitivePeerDependencies:
+      - '@types/node'
+      - conventional-commits-filter
+      - conventional-commits-parser
+      - typescript
+
+  '@commitlint/config-conventional@21.2.0':
+    dependencies:
+      '@commitlint/types': 21.2.0
+      conventional-changelog-conventionalcommits: 10.2.1
+
+  '@commitlint/config-validator@21.2.0':
+    dependencies:
+      '@commitlint/types': 21.2.0
+      ajv: 8.20.0
+
+  '@commitlint/ensure@21.2.0':
+    dependencies:
+      '@commitlint/types': 21.2.0
+      es-toolkit: 1.50.0
+
+  '@commitlint/execute-rule@21.0.1': {}
+
+  '@commitlint/format@21.2.0':
+    dependencies:
+      '@commitlint/types': 21.2.0
+      picocolors: 1.1.1
+
+  '@commitlint/is-ignored@21.2.0':
+    dependencies:
+      '@commitlint/types': 21.2.0
+      semver: 7.8.5
+
+  '@commitlint/lint@21.2.0':
+    dependencies:
+      '@commitlint/is-ignored': 21.2.0
+      '@commitlint/parse': 21.2.0
+      '@commitlint/rules': 21.2.0
+      '@commitlint/types': 21.2.0
+
+  '@commitlint/load@21.2.0(@types/node@26.1.1)(typescript@6.0.3)':
+    dependencies:
+      '@commitlint/config-validator': 21.2.0
+      '@commitlint/execute-rule': 21.0.1
+      '@commitlint/resolve-extends': 21.2.0
+      '@commitlint/types': 21.2.0
+      cosmiconfig: 9.0.2(typescript@6.0.3)
+      cosmiconfig-typescript-loader: 6.3.0(@types/node@26.1.1)(cosmiconfig@9.0.2(typescript@6.0.3))(typescript@6.0.3)
+      es-toolkit: 1.50.0
+      is-plain-obj: 4.1.0
+      picocolors: 1.1.1
+    transitivePeerDependencies:
+      - '@types/node'
+      - typescript
+
+  '@commitlint/message@21.2.0': {}
+
+  '@commitlint/parse@21.2.0':
+    dependencies:
+      '@commitlint/types': 21.2.0
+      conventional-changelog-angular: 9.2.1
+      conventional-commits-parser: 7.1.0
+
+  '@commitlint/read@21.2.1(conventional-commits-parser@7.1.0)':
+    dependencies:
+      '@commitlint/top-level': 21.2.0
+      '@commitlint/types': 21.2.0
+      '@conventional-changelog/git-client': 3.1.0(conventional-commits-parser@7.1.0)
+      tinyexec: 1.2.4
+    transitivePeerDependencies:
+      - conventional-commits-filter
+      - conventional-commits-parser
+
+  '@commitlint/resolve-extends@21.2.0':
+    dependencies:
+      '@commitlint/config-validator': 21.2.0
+      '@commitlint/types': 21.2.0
+      es-toolkit: 1.50.0
+      global-directory: 5.0.0
+      resolve-from: 5.0.0
+
+  '@commitlint/rules@21.2.0':
+    dependencies:
+      '@commitlint/ensure': 21.2.0
+      '@commitlint/message': 21.2.0
+      '@commitlint/to-lines': 21.0.1
+      '@commitlint/types': 21.2.0
+
+  '@commitlint/to-lines@21.0.1': {}
+
+  '@commitlint/top-level@21.2.0':
+    dependencies:
+      escalade: 3.2.0
+
+  '@commitlint/types@21.2.0':
+    dependencies:
+      conventional-commits-parser: 7.1.0
+      picocolors: 1.1.1
+
+  '@conventional-changelog/git-client@3.1.0(conventional-commits-parser@7.1.0)':
+    dependencies:
+      '@simple-libs/child-process-utils': 2.0.0
+      '@simple-libs/stream-utils': 2.0.0
+      semver: 7.8.5
+    optionalDependencies:
+      conventional-commits-parser: 7.1.0
+
+  '@conventional-changelog/template@1.2.1': {}
 
   '@date-fns/tz@1.2.0': {}
 
@@ -7758,6 +8044,12 @@ snapshots:
       domhandler: 5.0.3
       selderee: 0.11.0
 
+  '@simple-libs/child-process-utils@2.0.0':
+    dependencies:
+      '@simple-libs/stream-utils': 2.0.0
+
+  '@simple-libs/stream-utils@2.0.0': {}
+
   '@sindresorhus/merge-streams@4.0.0': {}
 
   '@smithy/core@3.29.8':
@@ -8249,12 +8541,16 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@6.2.3: {}
+
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.2
 
   argparse@2.0.1: {}
+
+  argue-cli@3.1.0: {}
 
   aria-hidden@1.2.6:
     dependencies:
@@ -8510,6 +8806,12 @@ snapshots:
 
   client-only@0.0.1: {}
 
+  cliui@9.0.1:
+    dependencies:
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+      wrap-ansi: 9.0.2
+
   clsx@2.1.1: {}
 
   code-block-writer@13.0.3: {}
@@ -8567,6 +8869,19 @@ snapshots:
 
   content-type@2.0.0: {}
 
+  conventional-changelog-angular@9.2.1:
+    dependencies:
+      '@conventional-changelog/template': 1.2.1
+
+  conventional-changelog-conventionalcommits@10.2.1:
+    dependencies:
+      '@conventional-changelog/template': 1.2.1
+
+  conventional-commits-parser@7.1.0:
+    dependencies:
+      '@simple-libs/stream-utils': 2.0.0
+      argue-cli: 3.1.0
+
   convert-source-map@1.9.0: {}
 
   convert-source-map@2.0.0: {}
@@ -8579,6 +8894,13 @@ snapshots:
     dependencies:
       object-assign: 4.1.1
       vary: 1.1.2
+
+  cosmiconfig-typescript-loader@6.3.0(@types/node@26.1.1)(cosmiconfig@9.0.2(typescript@6.0.3))(typescript@6.0.3):
+    dependencies:
+      '@types/node': 26.1.1
+      cosmiconfig: 9.0.2(typescript@6.0.3)
+      jiti: 2.6.1
+      typescript: 6.0.3
 
   cosmiconfig@7.1.0:
     dependencies:
@@ -8963,6 +9285,8 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  es-toolkit@1.50.0: {}
 
   esbuild-register@3.6.0(esbuild@0.25.12):
     dependencies:
@@ -9501,6 +9825,8 @@ snapshots:
 
   gensync@1.0.0-beta.2: {}
 
+  get-caller-file@2.0.5: {}
+
   get-east-asian-width@1.6.0: {}
 
   get-intrinsic@1.3.0:
@@ -9559,6 +9885,10 @@ snapshots:
       minimatch: 10.2.5
       minipass: 7.1.3
       path-scurry: 2.0.2
+
+  global-directory@5.0.0:
+    dependencies:
+      ini: 6.0.0
 
   global-modules@1.0.0:
     dependencies:
@@ -9716,6 +10046,8 @@ snapshots:
   inherits@2.0.4: {}
 
   ini@1.3.8: {}
+
+  ini@6.0.0: {}
 
   internal-slot@1.1.0:
     dependencies:
@@ -11100,6 +11432,8 @@ snapshots:
 
   resolve-from@4.0.0: {}
 
+  resolve-from@5.0.0: {}
+
   resolve-pkg-maps@1.0.0: {}
 
   resolve@1.22.12:
@@ -11930,6 +12264,12 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  wrap-ansi@9.0.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+
   wrappy@1.0.2: {}
 
   ws@8.21.1: {}
@@ -11946,12 +12286,25 @@ snapshots:
 
   xtend@4.0.2: {}
 
+  y18n@5.0.8: {}
+
   yallist@3.1.1: {}
 
   yaml@1.10.3: {}
 
   yaml@2.9.0:
     optional: true
+
+  yargs-parser@22.0.0: {}
+
+  yargs@18.0.0:
+    dependencies:
+      cliui: 9.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      string-width: 7.2.0
+      y18n: 5.0.8
+      yargs-parser: 22.0.0
 
   yjs@13.6.30:
     dependencies:


### PR DESCRIPTION
Closes #134

## What changed

Conventions that were previously honour-system are now enforced, and `CONTRIBUTING.md` is corrected to match.

**GitHub templates** (`.github/`, which did not exist)

- Two issue **forms** with `Acceptance criteria` marked `required: true`, so it is structurally impossible to file without it. Forms rather than markdown templates precisely because a markdown template can be deleted by the filer.
- Blank issues disabled, with a link to this guide.
- A PR template prompting for issue link, what changed, **how a reviewer verifies it**, and risk.
- `CODEOWNERS` so review is requested automatically.

**Local enforcement** (husky)

- `commit-msg` runs commitlint against `commitlint.config.mjs`.
- `pre-push` validates the branch name and blocks direct pushes to `main`. It is stdin-driven, so tag pushes and branch deletions are correctly exempt, and `git push origin mybranch:main` is caught.
- The existing `pre-commit` lint-staged hook is untouched.

**`CONTRIBUTING.md`**

- Types are the Conventional Commits set, and nothing else. The linter accepts exactly that list.
- Scopes documented as lower-case kebab-case and singular, enforced by a `scope-case` rule.
- Squash-merge policy, the two active rulesets, and the author-is-reviewer case are documented.
- Points at `README.md` for local setup rather than repeating it.

## Issue titles

Issue titles are **plain descriptive English** (`[Bug]: ...` / `[Request]: ...`), not Conventional Commits. An issue describes a problem, a commit describes a change — the type is a property of the eventual fix, unknowable at filing time. Type belongs in labels, which are filterable.

PR titles remain Conventional Commits, which matters more than usual here: with squash merging, the PR title *becomes* the commit on `main`, and no local hook can catch a bad one.

## Also done outside the diff

The four missing triage labels (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`) have been created. They are referenced by the new issue forms and by `docs/agents/triage-labels.md`, but only `wontfix` existed — GitHub silently drops unknown labels, so the forms would have applied nothing.

## How to verify

1. Try a bad commit locally — it should be rejected:
   `git commit --allow-empty -m "add stuff"`
2. Try a good one — it should pass:
   `git commit --allow-empty -m "chore(repo): check hook"`
3. Try pushing a badly named branch — `pre-push` should refuse it.
4. Open the "New issue" page and confirm the two forms appear, that blank issues are unavailable, and that `Acceptance criteria` cannot be left empty.

## Risk and rollout

Low. No application code, no runtime impact. Two dev dependencies (`@commitlint/cli`, `@commitlint/config-conventional`).

The one behaviour change for contributors is that malformed commit messages and branch names are now rejected locally.

## Dependency

`CONTRIBUTING.md` and the PR checklist require a clean `pnpm lint`. The repository does not currently satisfy that, so #136 must merge first.