### PR TITLE
fix(core): derive carousel scroll state with useSyncExternalStore

### DIFF
--- a/src/shared/components/ui/carousel.tsx
+++ b/src/shared/components/ui/carousel.tsx
@@ -59,14 +59,32 @@ function Carousel({
     },
     plugins,
   );
-  const [canScrollPrev, setCanScrollPrev] = React.useState(false);
-  const [canScrollNext, setCanScrollNext] = React.useState(false);
+  const subscribe = React.useCallback(
+    (onStoreChange: () => void) => {
+      if (!api) return () => {};
 
-  const onSelect = React.useCallback((api: CarouselApi) => {
-    if (!api) return;
-    setCanScrollPrev(api.canScrollPrev());
-    setCanScrollNext(api.canScrollNext());
-  }, []);
+      api.on("reInit", onStoreChange);
+      api.on("select", onStoreChange);
+
+      return () => {
+        api.off("reInit", onStoreChange);
+        api.off("select", onStoreChange);
+      };
+    },
+    [api],
+  );
+
+  const canScrollPrev = React.useSyncExternalStore(
+    subscribe,
+    () => api?.canScrollPrev() ?? false,
+    () => false,
+  );
+
+  const canScrollNext = React.useSyncExternalStore(
+    subscribe,
+    () => api?.canScrollNext() ?? false,
+    () => false,
+  );
 
   const scrollPrev = React.useCallback(() => {
     api?.scrollPrev();
@@ -93,17 +111,6 @@ function Carousel({
     if (!api || !setApi) return;
     setApi(api);
   }, [api, setApi]);
-
-  React.useEffect(() => {
-    if (!api) return;
-    onSelect(api);
-    api.on("reInit", onSelect);
-    api.on("select", onSelect);
-
-    return () => {
-      api?.off("select", onSelect);
-    };
-  }, [api, onSelect]);
 
   return (
     <CarouselContext.Provider


### PR DESCRIPTION
Closes #136

## What changed

`canScrollPrev` / `canScrollNext` were two `useState` values seeded by calling `onSelect(api)` synchronously inside an effect, which is what ESLint flagged — it schedules a second render immediately after mount.

They are now read through `useSyncExternalStore`, which is the primitive built for exactly this: subscribing to an external mutable source. Embla owns the scroll state; React reads it rather than mirroring it. Both `useState` calls and the whole subscription effect are gone.

This also fixes a listener leak the old effect had — it registered both `reInit` and `select`, but its cleanup only removed `select`.

## How to verify

1. `pnpm lint` — exits 0, where it previously exited 1
2. `npx tsc --noEmit` — passes
3. Load the landing page and confirm the hero slider still autoplays and loops

The hero slider is the only consumer and it does not render the prev/next buttons, so the enable/disable behaviour cannot be checked from the app. I bundled the component standalone and drove it in a browser instead:

| Position | `prev` disabled | `next` disabled |
| --- | --- | --- |
| Start | yes | no |
| Middle | no | no |
| End | no | yes |
| Back to middle | no | no |
| Back to start | yes | no |

No console errors.

## Risk and rollout

Low, but worth a look since it touches a shared UI primitive.

`useSyncExternalStore` is React 18+; this repo is on React 19. The snapshot getters return booleans, so the value-identity comparison is safe and cannot loop. The server snapshot returns `false`, matching the previous initial state, so SSR output is unchanged.

This diverges from upstream shadcn's carousel, so a future `shadcn add carousel` would overwrite it. That is already true of any local edit to a vendored component, but it is worth knowing.

## Note

Unblocks #134 — `CONTRIBUTING.md` and the PR checklist there require a clean `pnpm lint`.