### PR TITLE
ci(repo): run checks in CI and add the missing repository health files

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -32,6 +32,6 @@ migrations, or a note that this is safe and self-contained.
 - [ ] Branch is named `type/wids-<issue-number>`
 - [ ] Linked issue above, so it closes on merge
 - [ ] Everything is in English
-- [ ] `pnpm lint` and `npx tsc --noEmit` both pass
+- [ ] `pnpm lint`, `pnpm typecheck` and `pnpm test` all pass
 - [ ] Preview deployment builds successfully
 - [ ] Acceptance criteria on the linked issue are met

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      # Matches the Conventional Commits convention in CONTRIBUTING.md, so
+      # Dependabot's pull requests pass the same bar as everyone else's.
+      prefix: build
+      prefix-development: build
+      include: scope
+    groups:
+      # One pull request per ecosystem rather than a dozen — these move together.
+      payload:
+        patterns:
+          - "payload"
+          - "@payloadcms/*"
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+      dev-dependencies:
+        dependency-type: development
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: ci
+      include: scope

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+# A newer push to the same branch supersedes an in-flight run.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Lint, typecheck and test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Reads the version from the `packageManager` field in package.json.
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      # Runs even when linting fails, so one push surfaces every problem.
+      - name: Typecheck
+        if: ${{ !cancelled() }}
+        run: pnpm typecheck
+
+      - name: Test
+        if: ${{ !cancelled() }}
+        run: pnpm test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,12 @@ Two rulesets are active and will block a merge that does not satisfy them:
 
 ## CI/CD
 
-Every PR gets a preview deployment automatically. If the build fails, the PR will not be reviewed — fix the build first.
+Two things run on every PR, and both must pass before review:
+
+- **GitHub Actions** (`.github/workflows/ci.yml`) runs `pnpm lint`, `pnpm typecheck` and `pnpm test`.
+- **A preview deployment** is built automatically. If the build fails, the PR will not be reviewed — fix the build first.
+
+The production build is not repeated in Actions, because it needs a Postgres instance and the preview deployment already covers it.
 
 ## Local enforcement
 
@@ -130,4 +135,11 @@ Hooks run through husky:
 
 If a hook blocks something it should not, fix the name or message rather than passing `--no-verify`.
 
-`pnpm lint` and `npx tsc --noEmit` must both pass before you open a PR.
+Run these before opening a PR. Use pnpm scripts — never `npx`, which can resolve a different version than the `packageManager` field pins.
+
+| Command | What it checks |
+| ---------------- | ------------------------------------- |
+| `pnpm lint`      | eslint across the repository          |
+| `pnpm typecheck` | `tsc --noEmit`                        |
+| `pnpm test`      | vitest, once, non-watching            |
+| `pnpm build`     | the production build (needs Postgres) |

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Taws-Espol
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report security vulnerabilities privately, through GitHub:
+
+1. Go to the [Security tab](https://github.com/Taws-Espol/wids-website/security) of this repository
+2. Choose **Report a vulnerability**
+3. Describe the issue, the impact, and how to reproduce it
+
+**Do not open a public issue for a security problem.** Public issues are visible to everyone, including before a fix exists.
+
+You can expect an initial response within a week. If the report is confirmed we will agree a disclosure timeline with you before publishing anything.
+
+## Scope
+
+This repository is the WiDS Guayaquil website. Reports we are particularly interested in:
+
+- Access to registration data — attendee names, emails, national IDs and phone numbers are stored in this system
+- Flaws in the attendance token flow that would let someone confirm attendance for another person
+- Authentication or authorisation gaps in the Payload admin panel
+- Anything allowing writes to published content
+
+Out of scope: findings against `widsworldwide.org` or any other WiDS chapter, which are separate projects and should go to their own maintainers.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "payload migrate && next build",
     "start": "next start",
     "lint": "eslint",
+    "typecheck": "tsc --noEmit",
     "payload": "payload",
     "dev:email": "email dev --dir ./src/shared/lib/react-email",
     "prepare": "husky",
@@ -71,5 +72,6 @@
       "eslint --fix",
       "prettier --write"
     ]
-  }
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
Closes #140

## What changed

**CI.** There was no `.github/workflows/` directory at all. The only status on a pull request was GitHub's default CodeQL setup — a security scanner, not this project's checks. The eight tests added in #138 could break without anything going red.

`.github/workflows/ci.yml` now runs `pnpm lint`, `pnpm typecheck` and `pnpm test` on pull requests to `main` and on pushes to `main`. It installs with a frozen lockfile, takes the pnpm version from `packageManager`, and caches the store. Typecheck and test carry `if: ${{ !cancelled() }}` so one push surfaces every failure instead of stopping at the first.

The production build is deliberately **not** repeated here. It needs a Postgres instance, and the Coolify preview deployment already builds every PR.

**No more `npx`.** Added a `typecheck` script, so every check has a pnpm script. `npx` sidesteps the version pinned in `packageManager`. `CONTRIBUTING.md` and the PR template now list the four commands.

**Repository health files.**

- `LICENSE` — MIT. The repo is public with `"private": false` but had no licence, making it all-rights-reserved by default. `package.json` now declares `"license": "MIT"`.
- `SECURITY.md` — points at GitHub private vulnerability reporting, **now enabled** on the repository. The scope section names registration data explicitly, since this system stores attendee names, emails, national IDs and phone numbers.
- `.github/dependabot.yml` — npm weekly and github-actions monthly. Updates are grouped (payload, react, dev-dependencies) so it opens a few sensible PRs rather than a dozen. Commit prefixes are set to `build` and `ci` so Dependabot's PRs satisfy commitlint like everyone else's.

## How to verify

1. This PR is itself the test — the CI check should appear and pass.
2. To confirm it actually fails when it should, break something on a scratch branch and watch the run go red. I'll do this on the branch before merge and post the result.
3. `SECURITY.md` links resolve, and Security → Report a vulnerability is available.

## Risk and rollout

No application code. The one behaviour change is that PRs now have a required-looking status that can fail.

Worth deciding separately: whether to add this check to the `main` ruleset so a red run actually blocks merging. Right now it reports but does not gate.

## Note

Node is pinned to 24 in the workflow to match `flake.nix` (`pkgs.nodejs_24`). Local development is currently on Node 26, so a version-specific difference would show up here first — which is the point, but worth knowing.