### PR TITLE
fix(registration): keep the registration when its emails cannot be queued

### DIFF
--- a/src/shared/lib/payload/collections/conference-registrations.ts
+++ b/src/shared/lib/payload/collections/conference-registrations.ts
@@ -14,6 +14,7 @@ import { routing } from "../../next-intl/routing.ts";
 import type { Locale } from "../../next-intl/types.ts";
 import { tryCatch } from "../../../utils/try-catch.ts";
 import { createEventTypeValidationHook } from "../utils/create-event-type-validation.ts";
+import { createRegistrationEmailQueueHook } from "../utils/create-registration-email-queue-hook.ts";
 import { generateAttendanceToken } from "../utils/generate-attendance-token.ts";
 import { isAdminFieldAccess } from "../utils/is-admin-field-access.ts";
 import { isAdminOrEditor } from "../utils/is-admin-or-editor.ts";
@@ -21,17 +22,6 @@ import { validateProfessionalField } from "../utils/validate-professional-field.
 import { validateStudentField } from "../utils/validate-student-field.ts";
 import { validateUniqueEmailPerEvent } from "../utils/validate-unique-email-per-event.ts";
 import { validateUniquePhoneNumberPerEvent } from "../utils/validate-unique-phone-number-per-event.ts";
-
-const ONE_DAY_IN_MILLISECONDS = 24 * 60 * 60 * 1000 + 1000;
-
-function getRelationshipId(
-  value: number | { id: number } | null | undefined,
-): number | null {
-  if (value == null) {
-    return null;
-  }
-  return typeof value === "object" ? value.id : value;
-}
 
 export const ConferenceRegistrations: CollectionConfig = {
   slug: "conference-registrations",
@@ -244,81 +234,12 @@ export const ConferenceRegistrations: CollectionConfig = {
   hooks: {
     beforeValidate: [createEventTypeValidationHook("conference")],
     afterChange: [
-      async ({ doc, operation, req }) => {
-        if (operation !== "create") {
-          return;
-        }
-
-        const eventId = getRelationshipId(doc.event);
-        if (eventId == null) {
-          req.payload.logger.error({
-            err: new Error("Conference registration created without event id"),
-          });
-          return;
-        }
-
-        const locale =
-          (req.context as { conferenceRegistrationLocale?: Locale } | undefined)
-            ?.conferenceRegistrationLocale ?? routing.defaultLocale;
-
-        const { data: eventData, error: eventError } = await tryCatch(
-          req.payload.findByID({
-            collection: "events",
-            id: eventId,
-            depth: 0,
-            locale,
-            req,
-            select: {
-              date: true,
-              date_tz: true,
-            },
-          }),
-        );
-
-        if (eventError) {
-          req.payload.logger.error({
-            message:
-              "Failed to load event for conference registration email queue.",
-            error: eventError,
-          });
-          throw eventError;
-        }
-
-        const { error: queueError } = await tryCatch(
-          Promise.all([
-            req.payload.jobs.queue({
-              task: CONFERENCE_REGISTRATION_CONFIRMATION_TASK_SLUG,
-              input: {
-                registrationId: doc.id,
-                eventId,
-                locale,
-              },
-              queue: "critical",
-            }),
-            req.payload.jobs.queue({
-              task: CONFERENCE_REGISTRATION_REMINDER_TASK_SLUG,
-              input: {
-                registrationId: doc.id,
-                eventId,
-                locale,
-              },
-              queue: "batch",
-              waitUntil: new Date(
-                new Date(eventData.date).getTime() - ONE_DAY_IN_MILLISECONDS,
-              ),
-            }),
-          ]),
-        );
-
-        if (queueError) {
-          req.payload.logger.error({
-            message:
-              "Unexpected error while queueing mails for conference registration.",
-            error: queueError,
-          });
-          throw queueError;
-        }
-      },
+      createRegistrationEmailQueueHook({
+        label: "conference",
+        localeContextKey: "conferenceRegistrationLocale",
+        confirmationTaskSlug: CONFERENCE_REGISTRATION_CONFIRMATION_TASK_SLUG,
+        reminderTaskSlug: CONFERENCE_REGISTRATION_REMINDER_TASK_SLUG,
+      }),
     ],
   },
 };

--- a/src/shared/lib/payload/collections/datathon-registrations.ts
+++ b/src/shared/lib/payload/collections/datathon-registrations.ts
@@ -15,24 +15,13 @@ import { routing } from "../../next-intl/routing.ts";
 import type { Locale } from "../../next-intl/types.ts";
 import { tryCatch } from "../../../utils/try-catch.ts";
 import { createEventTypeValidationHook } from "../utils/create-event-type-validation.ts";
+import { createRegistrationEmailQueueHook } from "../utils/create-registration-email-queue-hook.ts";
 import { isAdminOrEditor } from "../utils/is-admin-or-editor.ts";
 import { validateDatathonTeams } from "../utils/validate-datathon-teams.ts";
 import { validateUniqueEmailPerEvent } from "../utils/validate-unique-email-per-event.ts";
 import { validateUniquePhoneNumberPerEvent } from "../utils/validate-unique-phone-number-per-event.ts";
 import { validateUniqueNationalIdPerEvent } from "../utils/validate-unique-national-id-per-event.ts";
 import { validateUniqueTeamNamePerEvent } from "../utils/validate-unique-team-name-per-event.ts";
-
-const ONE_DAY_IN_MILLISECONDS = 24 * 60 * 60 * 1000 + 1000;
-
-function getRelationshipId(
-  value: number | { id: number } | null | undefined,
-): number | null {
-  if (value == null) {
-    return null;
-  }
-
-  return typeof value === "object" ? value.id : value;
-}
 
 export const DatathonRegistrations: CollectionConfig = {
   slug: "datathon-registrations",
@@ -218,81 +207,12 @@ export const DatathonRegistrations: CollectionConfig = {
   hooks: {
     beforeValidate: [createEventTypeValidationHook("datathon")],
     afterChange: [
-      async ({ doc, operation, req }) => {
-        if (operation !== "create") {
-          return;
-        }
-
-        const eventId = getRelationshipId(doc.event);
-        if (eventId == null) {
-          req.payload.logger.error({
-            err: new Error("Datathon registration created without event id"),
-          });
-          return;
-        }
-
-        const locale =
-          (req.context as { datathonRegistrationLocale?: Locale } | undefined)
-            ?.datathonRegistrationLocale ?? routing.defaultLocale;
-
-        const { data: eventData, error: eventError } = await tryCatch(
-          req.payload.findByID({
-            collection: "events",
-            id: eventId,
-            depth: 0,
-            locale,
-            req,
-            select: {
-              date: true,
-              date_tz: true,
-            },
-          }),
-        );
-
-        if (eventError) {
-          req.payload.logger.error({
-            message:
-              "Failed to load event for Datathon registration email queue.",
-            error: eventError,
-          });
-          throw eventError;
-        }
-
-        const { error: queueError } = await tryCatch(
-          Promise.all([
-            req.payload.jobs.queue({
-              task: DATATHON_REGISTRATION_CONFIRMATION_TASK_SLUG,
-              input: {
-                registrationId: doc.id,
-                eventId,
-                locale,
-              },
-              queue: "critical",
-            }),
-            req.payload.jobs.queue({
-              task: DATATHON_REGISTRATION_REMINDER_TASK_SLUG,
-              input: {
-                registrationId: doc.id,
-                eventId,
-                locale,
-              },
-              queue: "batch",
-              waitUntil: new Date(
-                new Date(eventData.date).getTime() - ONE_DAY_IN_MILLISECONDS,
-              ),
-            }),
-          ]),
-        );
-
-        if (queueError) {
-          req.payload.logger.error({
-            message:
-              "Unexpected error while queueing mails for Datathon registration.",
-            error: queueError,
-          });
-          throw queueError;
-        }
-      },
+      createRegistrationEmailQueueHook({
+        label: "Datathon",
+        localeContextKey: "datathonRegistrationLocale",
+        confirmationTaskSlug: DATATHON_REGISTRATION_CONFIRMATION_TASK_SLUG,
+        reminderTaskSlug: DATATHON_REGISTRATION_REMINDER_TASK_SLUG,
+      }),
     ],
   },
 };

--- a/src/shared/lib/payload/utils/create-registration-email-queue-hook.ts
+++ b/src/shared/lib/payload/utils/create-registration-email-queue-hook.ts
@@ -1,0 +1,107 @@
+import type { CollectionAfterChangeHook, TypedJobs } from "payload";
+
+import { routing } from "../../next-intl/routing.ts";
+import type { Locale } from "../../next-intl/types.ts";
+import { tryCatch } from "../../../utils/try-catch.ts";
+import { getRelationshipId } from "./get-relationship-id.ts";
+
+/** The reminder is scheduled a day before the event, plus a second of slack. */
+const ONE_DAY_IN_MILLISECONDS = 24 * 60 * 60 * 1000 + 1000;
+
+type TaskSlug = keyof TypedJobs["tasks"];
+
+type Options = {
+  /** Names the registration in log messages, e.g. "conference". */
+  label: string;
+  /** Key the server action writes the submitting locale to on `req.context`. */
+  localeContextKey: string;
+  confirmationTaskSlug: TaskSlug;
+  reminderTaskSlug: TaskSlug;
+};
+
+/**
+ * Queues the confirmation and reminder emails after a registration is created.
+ *
+ * This hook never throws. It runs inside the surrounding `payload.create`, so
+ * throwing would roll the registration back and the person would be told their
+ * registration failed — losing the valuable thing to protect the disposable
+ * one. A failure is logged with the ids needed to requeue by hand, and the
+ * registration stands.
+ */
+export function createRegistrationEmailQueueHook({
+  label,
+  localeContextKey,
+  confirmationTaskSlug,
+  reminderTaskSlug,
+}: Options): CollectionAfterChangeHook {
+  return async ({ doc, operation, req }) => {
+    if (operation !== "create") {
+      return;
+    }
+
+    const eventId = getRelationshipId(doc.event);
+
+    if (eventId == null) {
+      req.payload.logger.error({
+        message: `${label} registration created without an event id; no emails queued.`,
+        registrationId: doc.id,
+      });
+
+      return;
+    }
+
+    const locale =
+      (req.context as Record<string, Locale | undefined> | undefined)?.[
+        localeContextKey
+      ] ?? routing.defaultLocale;
+
+    const context = { registrationId: doc.id, eventId, locale };
+
+    const { data: eventData, error: eventError } = await tryCatch(
+      req.payload.findByID({
+        collection: "events",
+        id: eventId,
+        depth: 0,
+        locale,
+        req,
+        select: { date: true, date_tz: true },
+      }),
+    );
+
+    if (eventError) {
+      req.payload.logger.error({
+        ...context,
+        error: eventError,
+        message: `Failed to load the event for a ${label} registration. The registration was kept; its emails were not queued.`,
+      });
+
+      return;
+    }
+
+    const { error: queueError } = await tryCatch(
+      Promise.all([
+        req.payload.jobs.queue({
+          task: confirmationTaskSlug,
+          input: { registrationId: doc.id, eventId, locale },
+          queue: "critical",
+        }),
+        req.payload.jobs.queue({
+          task: reminderTaskSlug,
+          input: { registrationId: doc.id, eventId, locale },
+          queue: "batch",
+          waitUntil: new Date(
+            new Date(eventData.date).getTime() - ONE_DAY_IN_MILLISECONDS,
+          ),
+        }),
+      ]),
+    );
+
+    if (queueError) {
+      req.payload.logger.error({
+        ...context,
+        error: queueError,
+        message: `Failed to queue emails for a ${label} registration. The registration was kept; requeue using the ids in this entry.`,
+      });
+    }
+  };
+}

--- a/src/shared/lib/payload/utils/get-relationship-id.ts
+++ b/src/shared/lib/payload/utils/get-relationship-id.ts
@@ -1,0 +1,13 @@
+/**
+ * Payload returns a relationship either as a bare id or as a populated
+ * document, depending on the query's `depth`.
+ */
+export function getRelationshipId(
+  value: number | { id: number } | null | undefined,
+): number | null {
+  if (value == null) {
+    return null;
+  }
+
+  return typeof value === "object" ? value.id : value;
+}

--- a/src/shared/tests/create-registration-email-queue-hook.test.ts
+++ b/src/shared/tests/create-registration-email-queue-hook.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createRegistrationEmailQueueHook } from "@/shared/lib/payload/utils/create-registration-email-queue-hook";
+
+const EVENT_DATE = "2026-05-12T09:00:00.000Z";
+
+const hook = createRegistrationEmailQueueHook({
+  label: "conference",
+  localeContextKey: "conferenceRegistrationLocale",
+  confirmationTaskSlug: "conference-registration-confirmation",
+  reminderTaskSlug: "conference-registration-reminder",
+});
+
+function createReq({
+  queue = vi.fn().mockResolvedValue(undefined),
+  findByID = vi.fn().mockResolvedValue({ date: EVENT_DATE }),
+} = {}) {
+  const error = vi.fn();
+
+  return {
+    req: {
+      payload: { logger: { error }, findByID, jobs: { queue } },
+      context: { conferenceRegistrationLocale: "es" },
+    },
+    error,
+    queue,
+    findByID,
+  };
+}
+
+/** The hook only ever receives these three fields from Payload. */
+function run(
+  req: unknown,
+  { operation = "create", doc = { id: 1, event: 7 } } = {},
+) {
+  return (
+    hook as unknown as (args: {
+      doc: unknown;
+      operation: string;
+      req: unknown;
+    }) => Promise<void>
+  )({ doc, operation, req });
+}
+
+describe("createRegistrationEmailQueueHook", () => {
+  it("queues a confirmation and a reminder when a registration is created", async () => {
+    const { req, queue } = createReq();
+
+    await run(req);
+
+    expect(queue).toHaveBeenCalledTimes(2);
+
+    const [confirmation, reminder] = queue.mock.calls.map(([args]) => args);
+
+    expect(confirmation).toMatchObject({
+      task: "conference-registration-confirmation",
+      queue: "critical",
+      input: { registrationId: 1, eventId: 7, locale: "es" },
+    });
+    expect(reminder).toMatchObject({
+      task: "conference-registration-reminder",
+      queue: "batch",
+    });
+
+    // Scheduled a day before the event.
+    const gap = new Date(EVENT_DATE).getTime() - reminder.waitUntil.getTime();
+    expect(gap).toBeGreaterThanOrEqual(24 * 60 * 60 * 1000);
+  });
+
+  it("does nothing on update", async () => {
+    const { req, queue, findByID } = createReq();
+
+    await run(req, { operation: "update" });
+
+    expect(queue).not.toHaveBeenCalled();
+    expect(findByID).not.toHaveBeenCalled();
+  });
+
+  // The point of #149: throwing here rolls back the surrounding payload.create,
+  // so the attendee loses their registration over an undeliverable email.
+  it("keeps the registration when queueing fails", async () => {
+    const { req, error } = createReq({
+      queue: vi.fn().mockRejectedValue(new Error("queue is down")),
+    });
+
+    await expect(run(req)).resolves.toBeUndefined();
+
+    expect(error).toHaveBeenCalledTimes(1);
+    expect(error.mock.calls[0][0]).toMatchObject({
+      registrationId: 1,
+      eventId: 7,
+      locale: "es",
+    });
+  });
+
+  it("keeps the registration when the event cannot be loaded", async () => {
+    const { req, error, queue } = createReq({
+      findByID: vi.fn().mockRejectedValue(new Error("database is down")),
+    });
+
+    await expect(run(req)).resolves.toBeUndefined();
+
+    expect(queue).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs and stops when the registration has no event", async () => {
+    const { req, error, queue } = createReq();
+
+    await expect(
+      run(req, { doc: { id: 2, event: null as unknown as number } }),
+    ).resolves.toBeUndefined();
+
+    expect(queue).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the default locale when the context carries none", async () => {
+    const { queue } = createReq();
+    const req = {
+      payload: {
+        logger: { error: vi.fn() },
+        findByID: vi.fn().mockResolvedValue({ date: EVENT_DATE }),
+        jobs: { queue },
+      },
+      context: {},
+    };
+
+    await run(req);
+
+    expect(queue.mock.calls[0][0].input.locale).toBe("es");
+  });
+});


### PR DESCRIPTION
Closes #149

## What changed

The `afterChange` hook on both registration collections rethrew when the event lookup or the job queue failed. That hook runs *inside* the surrounding `payload.create`, so the throw rolled the registration back — a transient queue problem discarded the attendee's place, and the server action reported `UNKNOWN`, telling them their registration had failed.

The registration is the valuable thing here; the confirmation email is not. The hook now logs the failure with the `registrationId`, `eventId` and `locale` needed to requeue by hand, and returns. The registration stands.

## Why this also moved the hook

The acceptance criteria asked for a test, and the hook was an anonymous closure inside the collection config object — not exported, not importable, so not reachable by a test without loading the whole `CollectionConfig` and indexing into `hooks.afterChange[0]`.

It is now `createRegistrationEmailQueueHook`, a named factory shared by both collections. That also removed the duplicated `getRelationshipId` helper and the `ONE_DAY_IN_MILLISECONDS` constant, which had been copy-pasted into both files.

Net **−173 lines** across the two collections, replaced by one 100-line module and six tests.

## How to verify

1. `pnpm test` — six new tests, no database and no DOM.
2. To confirm the tests are not vacuous, reinstate `throw queueError` in `create-registration-email-queue-hook.ts` and run them again. `keeps the registration when queueing fails` fails, and only that one. I ran this before opening the PR.
3. `pnpm build` passes against a local Postgres.

## Behaviour, before and after

| Situation | Before | After |
| --- | --- | --- |
| Queue rejects | registration rolled back, user sees `UNKNOWN` | registration kept, failure logged |
| Event lookup fails | registration rolled back | registration kept, failure logged |
| No event id on the doc | logged, returned | unchanged |
| `update` rather than `create` | no-op | unchanged |

## Risk and rollout

The failure mode changes from loud-and-destructive to quiet-and-logged. That is the intent, but it means a queue outage now shows up as registrations without confirmation emails rather than as failed registrations — the log entries carry every id needed to requeue.

Worth a follow-up: nothing currently alerts on those log entries, so a silent outage would only be noticed when someone reports a missing email. Out of scope here.