### PR TITLE
fix(registration): trim the email before checking uniqueness per event

### DIFF
--- a/src/shared/lib/payload/utils/create-unique-per-event-validator.ts
+++ b/src/shared/lib/payload/utils/create-unique-per-event-validator.ts
@@ -1,0 +1,70 @@
+import type { CollectionSlug, PayloadRequest } from "payload";
+
+/** The registration fields that must be unique within a single event. */
+export type UniqueField = "email" | "phoneNumber" | "nationalId" | "teamName";
+
+type Options = {
+  field: UniqueField;
+  /** Returned when the field is empty. */
+  requiredErrorCode: string;
+  /** Returned when another registration for the same event already has it. */
+  duplicateErrorCode: string;
+};
+
+/**
+ * The options Payload passes to a field validator. Declared structurally, and
+ * with only the parts this validator reads, so one implementation can back both
+ * text and email fields.
+ */
+export type ValidatorContext = {
+  req: PayloadRequest;
+  siblingData?: unknown;
+  data?: unknown;
+  collectionSlug?: string;
+};
+
+/**
+ * Builds a validator asserting a field is unique among registrations for the
+ * same event.
+ *
+ * Values are compared trimmed. These four rules used to be four copies of one
+ * function, and the email copy silently lost its `trim()` — see #147.
+ */
+export function createUniquePerEventValidator({
+  field,
+  requiredErrorCode,
+  duplicateErrorCode,
+}: Options) {
+  return async (
+    value: string | null | undefined,
+    { req, siblingData, data, collectionSlug }: ValidatorContext,
+  ): Promise<string | true> => {
+    if (!value) {
+      return requiredErrorCode;
+    }
+
+    const event = (siblingData as { event?: unknown } | undefined)?.event;
+
+    if (!event) {
+      return true;
+    }
+
+    const id =
+      data && typeof data === "object" && "id" in data
+        ? (data as { id?: string | number }).id
+        : undefined;
+
+    const existing = await req.payload.find({
+      collection: collectionSlug as CollectionSlug,
+      where: {
+        // Exclude the document being edited, so saving it again is not a clash.
+        id: id ? { not_equals: id } : { not_equals: null },
+        event: { equals: event },
+        [field]: { equals: value.trim() },
+      },
+      limit: 1,
+    });
+
+    return existing.totalDocs > 0 ? duplicateErrorCode : true;
+  };
+}

--- a/src/shared/lib/payload/utils/validate-unique-email-per-event.ts
+++ b/src/shared/lib/payload/utils/validate-unique-email-per-event.ts
@@ -1,45 +1,12 @@
-import type {
-  CollectionSlug,
-  EmailField,
-  EmailFieldValidation,
-  ValidateOptions,
-} from "payload";
+import type { EmailFieldValidation } from "payload";
 
 import { CONFERENCE_REGISTRATION_ERROR_CODES } from "@/shared/constants/conference-registration-error-codes";
 
-export const validateUniqueEmailPerEvent: EmailFieldValidation = async (
-  value,
-  {
-    req,
-    siblingData,
-    data,
-    collectionSlug,
-  }: ValidateOptions<
-    unknown,
-    Record<string, unknown>,
-    EmailField,
-    string | null | undefined
-  >,
-) => {
-  if (!value) return CONFERENCE_REGISTRATION_ERROR_CODES.EMAIL_REQUIRED;
+import { createUniquePerEventValidator } from "./create-unique-per-event-validator";
 
-  const event = siblingData?.event;
-
-  if (!event) return true;
-
-  const existing = await req.payload.find({
-    collection: collectionSlug as CollectionSlug,
-    where: {
-      ...(data && typeof data === "object" && "id" in data && data.id
-        ? { id: { not_equals: (data as { id: string | number }).id } }
-        : { id: { not_equals: null } }),
-      event: { equals: event },
-      email: { equals: value },
-    },
-    limit: 1,
+export const validateUniqueEmailPerEvent: EmailFieldValidation =
+  createUniquePerEventValidator({
+    field: "email",
+    requiredErrorCode: CONFERENCE_REGISTRATION_ERROR_CODES.EMAIL_REQUIRED,
+    duplicateErrorCode: CONFERENCE_REGISTRATION_ERROR_CODES.UNIQUE_EMAIL,
   });
-
-  return existing.totalDocs > 0
-    ? CONFERENCE_REGISTRATION_ERROR_CODES.UNIQUE_EMAIL
-    : true;
-};

--- a/src/shared/lib/payload/utils/validate-unique-national-id-per-event.ts
+++ b/src/shared/lib/payload/utils/validate-unique-national-id-per-event.ts
@@ -1,47 +1,12 @@
-import type {
-  CollectionSlug,
-  TextField,
-  TextFieldValidation,
-  ValidateOptions,
-} from "payload";
+import type { TextFieldValidation } from "payload";
 
 import { DATATHON_REGISTRATION_ERROR_CODES } from "@/shared/constants/datathon-registration-error-codes";
 
-export const validateUniqueNationalIdPerEvent: TextFieldValidation = async (
-  value,
-  {
-    req,
-    siblingData,
-    data,
-    collectionSlug,
-  }: ValidateOptions<
-    unknown,
-    Record<string, unknown>,
-    TextField,
-    string | null | undefined
-  >,
-) => {
-  if (!value) return DATATHON_REGISTRATION_ERROR_CODES.REQUIRED;
+import { createUniquePerEventValidator } from "./create-unique-per-event-validator";
 
-  const event = siblingData?.event;
-
-  if (!event) return true;
-
-  const trimmedValue = value.trim();
-
-  const existing = await req.payload.find({
-    collection: collectionSlug as CollectionSlug,
-    where: {
-      ...(data && typeof data === "object" && "id" in data && data.id
-        ? { id: { not_equals: (data as { id: string | number }).id } }
-        : { id: { not_equals: null } }),
-      event: { equals: event },
-      nationalId: { equals: trimmedValue },
-    },
-    limit: 1,
+export const validateUniqueNationalIdPerEvent: TextFieldValidation =
+  createUniquePerEventValidator({
+    field: "nationalId",
+    requiredErrorCode: DATATHON_REGISTRATION_ERROR_CODES.REQUIRED,
+    duplicateErrorCode: DATATHON_REGISTRATION_ERROR_CODES.UNIQUE_NATIONAL_ID,
   });
-
-  return existing.totalDocs > 0
-    ? DATATHON_REGISTRATION_ERROR_CODES.UNIQUE_NATIONAL_ID
-    : true;
-};

--- a/src/shared/lib/payload/utils/validate-unique-phone-number-per-event.ts
+++ b/src/shared/lib/payload/utils/validate-unique-phone-number-per-event.ts
@@ -1,47 +1,12 @@
-import type {
-  CollectionSlug,
-  TextField,
-  TextFieldValidation,
-  ValidateOptions,
-} from "payload";
+import type { TextFieldValidation } from "payload";
 
 import { CONFERENCE_REGISTRATION_ERROR_CODES } from "@/shared/constants/conference-registration-error-codes";
 
-export const validateUniquePhoneNumberPerEvent: TextFieldValidation = async (
-  value,
-  {
-    req,
-    siblingData,
-    data,
-    collectionSlug,
-  }: ValidateOptions<
-    unknown,
-    Record<string, unknown>,
-    TextField,
-    string | null | undefined
-  >,
-) => {
-  if (!value) return CONFERENCE_REGISTRATION_ERROR_CODES.PHONE_REQUIRED;
+import { createUniquePerEventValidator } from "./create-unique-per-event-validator";
 
-  const event = siblingData?.event;
-
-  if (!event) return true;
-
-  const trimmedValue = value.trim();
-
-  const existing = await req.payload.find({
-    collection: collectionSlug as CollectionSlug,
-    where: {
-      ...(data && typeof data === "object" && "id" in data && data.id
-        ? { id: { not_equals: (data as { id: string | number }).id } }
-        : { id: { not_equals: null } }),
-      event: { equals: event },
-      phoneNumber: { equals: trimmedValue },
-    },
-    limit: 1,
+export const validateUniquePhoneNumberPerEvent: TextFieldValidation =
+  createUniquePerEventValidator({
+    field: "phoneNumber",
+    requiredErrorCode: CONFERENCE_REGISTRATION_ERROR_CODES.PHONE_REQUIRED,
+    duplicateErrorCode: CONFERENCE_REGISTRATION_ERROR_CODES.UNIQUE_PHONE_NUMBER,
   });
-
-  return existing.totalDocs > 0
-    ? CONFERENCE_REGISTRATION_ERROR_CODES.UNIQUE_PHONE_NUMBER
-    : true;
-};

--- a/src/shared/lib/payload/utils/validate-unique-team-name-per-event.ts
+++ b/src/shared/lib/payload/utils/validate-unique-team-name-per-event.ts
@@ -1,47 +1,12 @@
-import type {
-  CollectionSlug,
-  TextField,
-  TextFieldValidation,
-  ValidateOptions,
-} from "payload";
+import type { TextFieldValidation } from "payload";
 
 import { DATATHON_REGISTRATION_ERROR_CODES } from "@/shared/constants/datathon-registration-error-codes";
 
-export const validateUniqueTeamNamePerEvent: TextFieldValidation = async (
-  value,
-  {
-    req,
-    siblingData,
-    data,
-    collectionSlug,
-  }: ValidateOptions<
-    unknown,
-    Record<string, unknown>,
-    TextField,
-    string | null | undefined
-  >,
-) => {
-  if (!value) return DATATHON_REGISTRATION_ERROR_CODES.REQUIRED;
+import { createUniquePerEventValidator } from "./create-unique-per-event-validator";
 
-  const event = siblingData?.event;
-
-  if (!event) return true;
-
-  const trimmedValue = value.trim();
-
-  const existing = await req.payload.find({
-    collection: collectionSlug as CollectionSlug,
-    where: {
-      ...(data && typeof data === "object" && "id" in data && data.id
-        ? { id: { not_equals: (data as { id: string | number }).id } }
-        : { id: { not_equals: null } }),
-      event: { equals: event },
-      teamName: { equals: trimmedValue },
-    },
-    limit: 1,
+export const validateUniqueTeamNamePerEvent: TextFieldValidation =
+  createUniquePerEventValidator({
+    field: "teamName",
+    requiredErrorCode: DATATHON_REGISTRATION_ERROR_CODES.REQUIRED,
+    duplicateErrorCode: DATATHON_REGISTRATION_ERROR_CODES.UNIQUE_TEAM_NAME,
   });
-
-  return existing.totalDocs > 0
-    ? DATATHON_REGISTRATION_ERROR_CODES.UNIQUE_TEAM_NAME
-    : true;
-};

--- a/src/shared/tests/create-unique-per-event-validator.test.ts
+++ b/src/shared/tests/create-unique-per-event-validator.test.ts
@@ -1,0 +1,110 @@
+import type { PayloadRequest, Where } from "payload";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createUniquePerEventValidator,
+  type UniqueField,
+  type ValidatorContext,
+} from "@/shared/lib/payload/utils/create-unique-per-event-validator";
+import { validateUniqueEmailPerEvent } from "@/shared/lib/payload/utils/validate-unique-email-per-event";
+import { validateUniqueNationalIdPerEvent } from "@/shared/lib/payload/utils/validate-unique-national-id-per-event";
+import { validateUniquePhoneNumberPerEvent } from "@/shared/lib/payload/utils/validate-unique-phone-number-per-event";
+import { validateUniqueTeamNamePerEvent } from "@/shared/lib/payload/utils/validate-unique-team-name-per-event";
+
+type FindArgs = { where: Where };
+type FindMock = ReturnType<typeof vi.fn<(args: FindArgs) => Promise<unknown>>>;
+
+function createContext({
+  totalDocs = 0,
+  data = {} as Record<string, unknown>,
+  hasEvent = true,
+} = {}) {
+  const find: FindMock = vi.fn().mockResolvedValue({ totalDocs });
+
+  const context: ValidatorContext = {
+    // A PayloadRequest carries 17 further properties the validator never
+    // touches, so the double supplies only `payload.find`.
+    req: { payload: { find } } as unknown as PayloadRequest,
+    siblingData: hasEvent ? { event: 7 } : {},
+    data,
+    collectionSlug: "conference-registrations",
+  };
+
+  return { find, context };
+}
+
+/** The four exported validators share one signature. */
+type Validator = (
+  value: string | null | undefined,
+  context: ValidatorContext,
+) => Promise<string | true>;
+
+const validator = createUniquePerEventValidator({
+  field: "email",
+  requiredErrorCode: "EMAIL_REQUIRED",
+  duplicateErrorCode: "UNIQUE_EMAIL",
+});
+
+describe("createUniquePerEventValidator", () => {
+  it("passes when no other registration for the event has the value", async () => {
+    const { context } = createContext({ totalDocs: 0 });
+
+    await expect(validator("ana@example.com", context)).resolves.toBe(true);
+  });
+
+  it("rejects when another registration for the event already has it", async () => {
+    const { context } = createContext({ totalDocs: 1 });
+
+    await expect(validator("ana@example.com", context)).resolves.toBe(
+      "UNIQUE_EMAIL",
+    );
+  });
+
+  it("returns the required code for an empty value", async () => {
+    const { context, find } = createContext();
+
+    await expect(validator("", context)).resolves.toBe("EMAIL_REQUIRED");
+    expect(find).not.toHaveBeenCalled();
+  });
+
+  it("skips the check when the row has no event yet", async () => {
+    const { context, find } = createContext({ hasEvent: false });
+
+    await expect(validator("ana@example.com", context)).resolves.toBe(true);
+    expect(find).not.toHaveBeenCalled();
+  });
+
+  it("excludes the document being edited, so re-saving is not a clash", async () => {
+    const { context, find } = createContext({ data: { id: 42 } });
+
+    await validator("ana@example.com", context);
+
+    expect(find.mock.calls[0][0].where.id).toEqual({ not_equals: 42 });
+  });
+});
+
+// #147: the email validator had lost its trim() while the other three kept it.
+describe("every unique-per-event validator trims before comparing", () => {
+  const cases: Array<[string, Validator, UniqueField]> = [
+    ["email", validateUniqueEmailPerEvent as Validator, "email"],
+    [
+      "phone number",
+      validateUniquePhoneNumberPerEvent as Validator,
+      "phoneNumber",
+    ],
+    [
+      "national id",
+      validateUniqueNationalIdPerEvent as Validator,
+      "nationalId",
+    ],
+    ["team name", validateUniqueTeamNamePerEvent as Validator, "teamName"],
+  ];
+
+  it.each(cases)("%s", async (_label, validate, field) => {
+    const { context, find } = createContext();
+
+    await validate("  spaced  ", context);
+
+    expect(find.mock.calls[0][0].where[field]).toEqual({ equals: "spaced" });
+  });
+});


### PR DESCRIPTION
Closes #147

## What changed

The email uniqueness check compared the raw value, while the national id, phone number and team name checks all compared a trimmed one. An address differing only by surrounding whitespace was treated as a different address, so the rule did not fire.

The four validators were copies of one 47-line function differing in a field name and two error codes — which is exactly how the divergence went unnoticed. They now share one implementation, so a rule cannot drift in a single copy again.

## Scope of the defect — narrower than the issue assumed

While fixing this I checked how values reach the validator. The **website path was never affected**: the zod schema already applies `.trim().toLowerCase()` to email before the server action runs (`src/features/registration/schemas/conference-registration.ts:13`).

The exposure is the **Payload admin panel**, which bypasses zod entirely. A registration typed there with a trailing space would not be recognised as a duplicate.

That also answers the issue's question about existing rows: registrations created through the website are already trimmed and lowercased, so a blind data migration is not warranted. If admin-created rows are a concern, a one-off query is the right tool, and I have not run one.

## Related: case sensitivity

zod lowercases email, but the validator compares case-sensitively. So `Ana@example.com` entered in the admin panel and `ana@example.com` from the website are not detected as duplicates. That is the same class of bug and arguably part of "the same email", but it is not what #147 describes, so I have left it alone rather than widening the fix silently. Happy to file it.

## How to verify

1. `pnpm test` — the trimming behaviour of all four validators is covered by a table-driven test.
2. To confirm the tests are not vacuous, remove `.trim()` from `create-unique-per-event-validator.ts` and run them again: exactly four fail, one per field. I ran this before opening the PR.

## Risk and rollout

Behaviour changes only for values with surrounding whitespace, which previously slipped through. No schema or data changes.

The four exported validator names and their types are unchanged, so no call site in the collections moved.