### PR TITLE
fix(registration): show student and professional errors on their fields

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -135,8 +135,6 @@
           "accepted-terms-required": "You must accept the terms and conditions.",
           "email-required": "Email is required.",
           "email-duplicate": "An email in this team is already registered for this event.",
-          "national-id-required": "National ID is required.",
-          "national-id-duplicate": "A national ID in this team is already registered for this event.",
           "phone-number-required": "Phone number is required.",
           "phone-number-duplicate": "A phone number in this team is already registered for this event.",
           "student-field-required": "This field is required for students.",

--- a/src/features/registration/hooks/use-conference-registration-form.tsx
+++ b/src/features/registration/hooks/use-conference-registration-form.tsx
@@ -12,6 +12,7 @@ import {
 
 import { registerForConferenceAction } from "@/features/registration/actions/register-for-conference";
 import { conferenceRegistrationSchema } from "@/features/registration/schemas/conference-registration";
+import { mapConferenceRegistrationError } from "@/features/registration/utils/map-conference-registration-error";
 import type { ConferenceRegistrationValues } from "@/features/registration/types/conference-registration";
 
 interface Props {
@@ -65,38 +66,14 @@ export const useConferenceRegistrationForm = ({
     );
 
     if (error) {
-      switch (error.code) {
-        case "SCHEMA_VALIDATION":
-          form.setError("root.serverError", {
-            message: "errors.schema-validation",
-          });
-          return;
-        case "UNIQUE_EMAIL":
-          form.setError("email", {
-            message: "validation.email-duplicate",
-          });
-          return;
-        case "UNIQUE_PHONE_NUMBER":
-          form.setError("phoneNumber", {
-            message: "validation.phone-number-duplicate",
-          });
-          return;
-        case "PAYLOAD_VALIDATION":
-          form.setError("root.serverError", {
-            message: "errors.payload-validation",
-          });
-          return;
-        case "UNKNOWN":
-          form.setError("root.serverError", {
-            message: "errors.unknown",
-          });
-          return;
-        default:
-          form.setError("root.serverError", {
-            message: "errors.unknown",
-          });
-          return;
+      for (const { field, message } of mapConferenceRegistrationError(
+        error.code,
+        form.getValues(),
+      )) {
+        form.setError(field, { message });
       }
+
+      return;
     }
 
     toast.success(t("states.success"));

--- a/src/features/registration/tests/map-conference-registration-error.test.ts
+++ b/src/features/registration/tests/map-conference-registration-error.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+
+import { mapConferenceRegistrationError } from "@/features/registration/utils/map-conference-registration-error";
+import {
+  CONFERENCE_REGISTRATION_ERROR_CODES,
+  type ConferenceRegistrationErrorCode,
+} from "@/shared/constants/conference-registration-error-codes";
+
+const ALL_CODES = Object.values(
+  CONFERENCE_REGISTRATION_ERROR_CODES,
+) as ConferenceRegistrationErrorCode[];
+
+describe("mapConferenceRegistrationError", () => {
+  // #148: these two reached the user as the generic "unknown" message, because
+  // the hook's switch had no case for them.
+  it("places a student field error on the fields left empty", () => {
+    expect(
+      mapConferenceRegistrationError("STUDENT_FIELD_REQUIRED", {
+        universityName: "",
+        major: "Data Science",
+      }),
+    ).toEqual([
+      { field: "universityName", message: "validation.student-field-required" },
+    ]);
+  });
+
+  it("places a professional field error on the fields left empty", () => {
+    expect(
+      mapConferenceRegistrationError("PROFESSIONAL_FIELD_REQUIRED", {
+        organizationName: "ESPOL",
+        jobTitle: "",
+      }),
+    ).toEqual([
+      { field: "jobTitle", message: "validation.professional-field-required" },
+    ]);
+  });
+
+  it("flags every branch field when the client cannot tell which one failed", () => {
+    expect(
+      mapConferenceRegistrationError("STUDENT_FIELD_REQUIRED", {
+        universityName: "ESPOL",
+        major: "Data Science",
+      }).map(({ field }) => field),
+    ).toEqual(["universityName", "major"]);
+  });
+
+  it.each([
+    ["UNIQUE_EMAIL", "email"],
+    ["EMAIL_REQUIRED", "email"],
+    ["INVALID_EMAIL", "email"],
+    ["UNIQUE_PHONE_NUMBER", "phoneNumber"],
+    ["PHONE_REQUIRED", "phoneNumber"],
+    ["INVALID_PHONE_NUMBER", "phoneNumber"],
+    ["ACCEPTED_TERMS_REQUIRED", "acceptedTerms"],
+  ] as Array<[ConferenceRegistrationErrorCode, string]>)(
+    "%s targets the %s field",
+    (code, field) => {
+      expect(mapConferenceRegistrationError(code, {})).toEqual([
+        { field, message: expect.any(String) },
+      ]);
+    },
+  );
+
+  it.each([
+    "SCHEMA_VALIDATION",
+    "PAYLOAD_VALIDATION",
+    "UNKNOWN",
+    "REQUIRED",
+  ] as ConferenceRegistrationErrorCode[])(
+    "%s falls back to the banner, having no field to point at",
+    (code) => {
+      expect(mapConferenceRegistrationError(code, {})[0].field).toBe(
+        "root.serverError",
+      );
+    },
+  );
+
+  // Guards the whole point of #148: a code that nothing handles must not
+  // silently degrade to the generic message.
+  it("handles every declared error code", () => {
+    for (const code of ALL_CODES) {
+      const result = mapConferenceRegistrationError(code, {});
+
+      expect(result.length).toBeGreaterThan(0);
+      expect(result[0].message).toEqual(expect.any(String));
+    }
+  });
+
+  it("throws rather than degrading when given an unknown code", () => {
+    expect(() =>
+      mapConferenceRegistrationError(
+        "NOT_A_REAL_CODE" as ConferenceRegistrationErrorCode,
+        {},
+      ),
+    ).toThrow(/Unhandled conference registration error/);
+  });
+});

--- a/src/features/registration/utils/map-conference-registration-error.ts
+++ b/src/features/registration/utils/map-conference-registration-error.ts
@@ -1,0 +1,109 @@
+import type { ConferenceRegistrationErrorCode } from "@/shared/constants/conference-registration-error-codes";
+
+import type { ConferenceRegistrationValues } from "@/features/registration/types/conference-registration";
+
+/**
+ * Where a server error should be shown. `root.serverError` is the banner above
+ * the submit button, used only when a code cannot be tied to a field.
+ */
+export type ConferenceRegistrationFieldError = {
+  field: keyof ConferenceRegistrationValues | "root.serverError";
+  /** A translation key, resolved by the caller. */
+  message: string;
+};
+
+/** The branch fields each participant type must fill in. */
+const STUDENT_FIELDS = ["universityName", "major"] as const;
+const PROFESSIONAL_FIELDS = ["organizationName", "jobTitle"] as const;
+
+/**
+ * Places a server error code onto the fields it concerns.
+ *
+ * Kept separate from the form hook so the mapping can be tested without a
+ * renderer. The switch is exhaustive: adding a code to
+ * CONFERENCE_REGISTRATION_ERROR_CODES without handling it here fails the
+ * typecheck rather than silently degrading to the generic message, which is
+ * what happened to the student and professional codes — see #148.
+ */
+export function mapConferenceRegistrationError(
+  code: ConferenceRegistrationErrorCode,
+  values: Partial<ConferenceRegistrationValues>,
+): ConferenceRegistrationFieldError[] {
+  switch (code) {
+    case "UNIQUE_EMAIL":
+      return [{ field: "email", message: "validation.email-duplicate" }];
+    case "EMAIL_REQUIRED":
+      return [{ field: "email", message: "validation.email-required" }];
+    case "INVALID_EMAIL":
+      return [{ field: "email", message: "validation.invalid-email" }];
+    case "UNIQUE_PHONE_NUMBER":
+      return [
+        { field: "phoneNumber", message: "validation.phone-number-duplicate" },
+      ];
+    case "PHONE_REQUIRED":
+      return [
+        { field: "phoneNumber", message: "validation.phone-number-required" },
+      ];
+    case "INVALID_PHONE_NUMBER":
+      return [
+        { field: "phoneNumber", message: "validation.invalid-phone-number" },
+      ];
+
+    case "ACCEPTED_TERMS_REQUIRED":
+      return [
+        {
+          field: "acceptedTerms",
+          message: "validation.accepted-terms-required",
+        },
+      ];
+
+    // The code says a branch field is missing but not which one, so target the
+    // ones the user actually left empty.
+    case "STUDENT_FIELD_REQUIRED":
+      return emptyBranchFields(
+        STUDENT_FIELDS,
+        values,
+        "validation.student-field-required",
+      );
+    case "PROFESSIONAL_FIELD_REQUIRED":
+      return emptyBranchFields(
+        PROFESSIONAL_FIELDS,
+        values,
+        "validation.professional-field-required",
+      );
+
+    case "SCHEMA_VALIDATION":
+      return [
+        { field: "root.serverError", message: "errors.schema-validation" },
+      ];
+    case "PAYLOAD_VALIDATION":
+      return [
+        { field: "root.serverError", message: "errors.payload-validation" },
+      ];
+
+    // REQUIRED carries no field, so it can only be shown as a banner.
+    case "REQUIRED":
+    case "UNKNOWN":
+      return [{ field: "root.serverError", message: "errors.unknown" }];
+
+    default: {
+      const unhandled: never = code;
+
+      throw new Error(`Unhandled conference registration error: ${unhandled}`);
+    }
+  }
+}
+
+function emptyBranchFields(
+  fields: ReadonlyArray<keyof ConferenceRegistrationValues>,
+  values: Partial<ConferenceRegistrationValues>,
+  message: string,
+): ConferenceRegistrationFieldError[] {
+  const empty = fields.filter((field) => !values[field]);
+
+  // If the client cannot tell which one the server meant, flag them all.
+  return (empty.length > 0 ? empty : fields).map((field) => ({
+    field,
+    message,
+  }));
+}


### PR DESCRIPTION
Closes #148

## What changed

`validateStudentField` and `validateProfessionalField` return `STUDENT_FIELD_REQUIRED` and `PROFESSIONAL_FIELD_REQUIRED`. The form hook's switch handled five codes out of eleven, so both fell through to `default` and reached the user as the generic unknown error — the work of producing a specific code was done and then discarded.

The mapping now lives in a pure function with an **exhaustive switch**. Adding a code to `CONFERENCE_REGISTRATION_ERROR_CODES` without handling it fails the typecheck rather than silently degrading, which is exactly how these two got lost.

All eleven codes are now handled. Field-specific codes target their field; only `SCHEMA_VALIDATION`, `PAYLOAD_VALIDATION`, `REQUIRED` and `UNKNOWN` fall back to the banner, because they carry no field information.

## Which field?

The two branch codes say *a* field is missing, not which one — student covers `universityName` and `major`, professional covers `organizationName` and `jobTitle`. The mapping reads the submitted values and targets the ones actually left empty, falling back to flagging both when it cannot tell.

## Translations

Every message reuses a key that already existed in **both** locales — `validation.student-field-required` and `validation.professional-field-required` were already there, used by the zod schema for the client-side version of the same rule. No new copy was needed.

While checking that, I found two keys present only in `en` — `national-id-duplicate` and `national-id-required` — in the conference namespace, for a field the conference form does not have. Dropped, so the two namespaces now match exactly.

## How to verify

1. `pnpm test` — ten tests, including one asserting every declared code produces a mapping.
2. To confirm the exhaustiveness guard is real, delete any `case` from the switch and run `pnpm typecheck`: it fails with `Type '"ACCEPTED_TERMS_REQUIRED"' is not assignable to type 'never'`. I ran this before opening the PR.

## Risk and rollout

The hook's behaviour is unchanged for the five codes it already handled — same fields, same message keys. Six codes that previously showed the generic banner now show something specific.

Note these codes only surface when Payload's validators reject something zod let through, which in practice means drift between the two rule sets or an edit made in the admin panel. The user-visible improvement is therefore narrow; the durable part is that a future code cannot go unhandled unnoticed.

## Ordering

Independent of #156 and #158, and touches no files they touch.