### PR TITLE
fix(registration): remove the unused eventDate prop from both dialogs

### DIFF
--- a/src/app/(wids)/[locale]/conference/page.tsx
+++ b/src/app/(wids)/[locale]/conference/page.tsx
@@ -53,7 +53,6 @@ export default async function Conference({
               <ConferenceRegistrationDialog
                 ctaLabel={t("cta")}
                 eventId={event.id}
-                eventDate={event.date}
                 registrationStart={event.registrationStart ?? ""}
                 registrationEnd={event.registrationEnd ?? ""}
               />

--- a/src/app/(wids)/[locale]/learn/datathon/page.tsx
+++ b/src/app/(wids)/[locale]/learn/datathon/page.tsx
@@ -55,7 +55,6 @@ export default async function Datathon({
               <DatathonRegistrationDialog
                 ctaLabel={t("cta")}
                 eventId={event.id}
-                eventDate={event.date}
                 registrationStart={event.registrationStart ?? ""}
                 registrationEnd={event.registrationEnd ?? ""}
               />

--- a/src/features/registration/components/conference-registration-dialog.tsx
+++ b/src/features/registration/components/conference-registration-dialog.tsx
@@ -22,7 +22,6 @@ import { useConferenceRegistrationDialog } from "@/features/registration/hooks/u
 type Props = {
   ctaLabel: string;
   eventId: number;
-  eventDate: string;
   registrationStart: string;
   registrationEnd: string;
 };

--- a/src/features/registration/components/datathon-registration-dialog.tsx
+++ b/src/features/registration/components/datathon-registration-dialog.tsx
@@ -31,7 +31,6 @@ import { useDatathonRegistrationDialog } from "@/features/registration/hooks/use
 type Props = {
   ctaLabel: string;
   eventId: number;
-  eventDate: string;
   registrationStart: string;
   registrationEnd: string;
 };


### PR DESCRIPTION
Closes #154

## What changed

Both registration dialogs declared an `eventDate` prop, destructured it, and never read it. Two call sites fetched and passed a value that had no effect.

The registration-window guard both dialogs run uses `registrationStart` and `registrationEnd`, so nothing depended on `eventDate`.

Removed from:

- `conference-registration-dialog.tsx`
- `datathon-registration-dialog.tsx`
- the two pages that passed it

## How to verify

`pnpm typecheck` — a prop still passed to a component that no longer accepts it would fail, so a clean typecheck is the check here. `pnpm lint` and `pnpm test` also pass.

## Risk and rollout

None. The value was inert.