### PR TITLE
fix(registration): return an error code from the nextgen terms validator

### DIFF
--- a/src/shared/lib/payload/collections/nextgen-registrations.ts
+++ b/src/shared/lib/payload/collections/nextgen-registrations.ts
@@ -3,6 +3,7 @@ import type { CollectionConfig } from "payload";
 import { HEARD_ABOUT_OPTIONS } from "../constants/registrations.ts";
 import { createEventTypeValidationHook } from "../utils/create-event-type-validation.ts";
 import { isAdminOrEditor } from "../utils/is-admin-or-editor.ts";
+import { CONFERENCE_REGISTRATION_ERROR_CODES } from "../../../constants/conference-registration-error-codes.ts";
 import { validateUniqueEmailPerEvent } from "../utils/validate-unique-email-per-event.ts";
 import { validateUniquePhoneNumberPerEvent } from "../utils/validate-unique-phone-number-per-event.ts";
 
@@ -96,7 +97,9 @@ export const NextgenRegistrations: CollectionConfig = {
       required: true,
       label: "I accept the terms and conditions",
       validate: (value) =>
-        value ? true : "You must accept the terms and conditions.",
+        value
+          ? true
+          : CONFERENCE_REGISTRATION_ERROR_CODES.ACCEPTED_TERMS_REQUIRED,
     },
     {
       name: "heardAboutEvent",


### PR DESCRIPTION
Closes #153

## What changed

The nextgen `acceptedTerms` validator returned a hardcoded English sentence; the other three registration collections return an error code for the same rule.

It now returns `CONFERENCE_REGISTRATION_ERROR_CODES.ACCEPTED_TERMS_REQUIRED`.

## Why that constant, and not a new nextgen enum

Nextgen already emits conference codes — its email and phone fields use the shared `validateUniqueEmailPerEvent` and `validateUniquePhoneNumberPerEvent`, which return `CONFERENCE_REGISTRATION_ERROR_CODES`. Adding a parallel nextgen enum for one field would have left the collection speaking two vocabularies.

The constant is arguably misnamed — it is really a shared registration vocabulary that happens to carry the conference prefix — but renaming it touches four collections and is not this issue.

## Two things worth knowing

**Nextgen has no client path.** No form, action or schema writes to `nextgen-registrations`; the only audience for this value is the Payload admin panel. So the issue's acceptance criterion about the client mapping the code to a translated message has nothing to map it — there is no client.

**That means this is not a user-visible improvement, and arguably a small regression for admins:** they previously saw "You must accept the terms and conditions." and will now see `ACCEPTED_TERMS_REQUIRED`. That is already what the other three collections show them, so this makes the four consistent rather than making nextgen worse than its siblings — but it is worth naming rather than glossing over.

If readable admin messages matter, the fix is to give Payload a message resolver for these codes across all four collections. Happy to file that; it is a different change from this one.

## How to verify

`pnpm lint`, `pnpm typecheck` and `pnpm test` pass. Grepping the collections for raw-string validators returns nothing.