### PR TITLE
chore(registration): remove the dead email-queueing block from datathon individuals

### DIFF
--- a/src/shared/lib/payload/collections/datathon-registrations-individuals.ts
+++ b/src/shared/lib/payload/collections/datathon-registrations-individuals.ts
@@ -7,30 +7,11 @@ import {
   HEARD_ABOUT_OPTIONS,
   SEX_OPTIONS,
 } from "../constants/registrations.ts";
-// import {
-//   DATATHON_REGISTRATION_CONFIRMATION_TASK_SLUG,
-//   DATATHON_REGISTRATION_REMINDER_TASK_SLUG,
-// } from "../constants/slugs.ts";
-// import { routing } from "../../next-intl/routing.ts";
-// import type { Locale } from "../../next-intl/types.ts";
-// import { tryCatch } from "../../../utils/try-catch.ts";
 import { createEventTypeValidationHook } from "../utils/create-event-type-validation.ts";
 import { isAdminOrEditor } from "../utils/is-admin-or-editor.ts";
 import { validateUniqueEmailPerEvent } from "../utils/validate-unique-email-per-event.ts";
 import { validateUniquePhoneNumberPerEvent } from "../utils/validate-unique-phone-number-per-event.ts";
 import { validateUniqueNationalIdPerEvent } from "../utils/validate-unique-national-id-per-event.ts";
-
-// const ONE_DAY_IN_MILLISECONDS = 24 * 60 * 60 * 1000 + 1000;
-
-// function getRelationshipId(
-//   value: number | { id: number } | null | undefined,
-// ): number | null {
-//   if (value == null) {
-//     return null;
-//   }
-
-//   return typeof value === "object" ? value.id : value;
-// }
 
 export const DatathonRegistrationsIndividuals: CollectionConfig = {
   slug: "datathon-registrations-individuals",
@@ -187,82 +168,12 @@ export const DatathonRegistrationsIndividuals: CollectionConfig = {
   ],
   hooks: {
     beforeValidate: [createEventTypeValidationHook("datathon")],
-    // afterChange: [
-    //   async ({ doc, operation, req }) => {
-    //     if (operation !== "create") {
-    //       return;
-    //     }
 
-    //     const eventId = getRelationshipId(doc.event);
-    //     if (eventId == null) {
-    //       req.payload.logger.error({
-    //         err: new Error("Datathon registration created without event id"),
-    //       });
-    //       return;
-    //     }
-
-    //     const locale =
-    //       (req.context as { datathonRegistrationLocale?: Locale } | undefined)
-    //         ?.datathonRegistrationLocale ?? routing.defaultLocale;
-
-    //     const { data: eventData, error: eventError } = await tryCatch(
-    //       req.payload.findByID({
-    //         collection: "events",
-    //         id: eventId,
-    //         depth: 0,
-    //         locale,
-    //         req,
-    //         select: {
-    //           date: true,
-    //           date_tz: true,
-    //         },
-    //       }),
-    //     );
-
-    //     if (eventError) {
-    //       req.payload.logger.error({
-    //         message:
-    //           "Failed to load event for Datathon registration email queue.",
-    //         error: eventError,
-    //       });
-    //       throw eventError;
-    //     }
-
-    //     const { error: queueError } = await tryCatch(
-    //       Promise.all([
-    //         req.payload.jobs.queue({
-    //           task: DATATHON_REGISTRATION_CONFIRMATION_TASK_SLUG,
-    //           input: {
-    //             registrationId: doc.id,
-    //             eventId,
-    //             locale,
-    //           },
-    //           queue: "critical",
-    //         }),
-    //         req.payload.jobs.queue({
-    //           task: DATATHON_REGISTRATION_REMINDER_TASK_SLUG,
-    //           input: {
-    //             registrationId: doc.id,
-    //             eventId,
-    //             locale,
-    //           },
-    //           queue: "batch",
-    //           waitUntil: new Date(
-    //             new Date(eventData.date).getTime() - ONE_DAY_IN_MILLISECONDS,
-    //           ),
-    //         }),
-    //       ]),
-    //     );
-
-    //     if (queueError) {
-    //       req.payload.logger.error({
-    //         message:
-    //           "Unexpected error while queueing mails for Datathon registration.",
-    //         error: queueError,
-    //       });
-    //       throw queueError;
-    //     }
-    //   },
-    // ],
+    /*
+     * No afterChange email queueing, unlike conference-registrations and
+     * datathon-registrations. Individual registrants are not sent confirmation
+     * or reminder emails, and never have been. If that changes, use
+     * createRegistrationEmailQueueHook rather than reimplementing it here.
+     */
   },
 };


### PR DESCRIPTION
Closes #150

## What changed

The collection carried **87 commented-out lines** — about a third of the file — reproducing the `afterChange` email-queueing block from the other two registration collections, along with the imports, `ONE_DAY_IN_MILLISECONDS` constant and `getRelationshipId` helper it needed.

Removed, and the decision recorded where the hook would have gone:

```ts
/*
 * No afterChange email queueing, unlike conference-registrations and
 * datathon-registrations. Individual registrants are not sent confirmation
 * or reminder emails, and never have been. If that changes, use
 * createRegistrationEmailQueueHook rather than reimplementing it here.
 */
```

**269 → 174 lines.**

## Why delete rather than implement

Individual registrants have never received these emails — nothing ever uncommented the block. Deleting it matches current behaviour; implementing it would have been a product change disguised as a cleanup.

The block also demonstrates the cost of keeping code in comments: the two live copies it was cloned from were consolidated into `createRegistrationEmailQueueHook` in #149, and this one silently did not follow, because nothing lints, typechecks or tests a comment.

## How to verify

`pnpm lint`, `pnpm typecheck`, `pnpm test` all pass. The collection's live behaviour is untouched — `beforeValidate` still runs the event-type check.

## Risk and rollout

None. Nothing executed before, and nothing executes now.