### PR TITLE
fix(registration): narrow Payload error messages instead of casting them

### DIFF
--- a/src/features/registration/actions/register-for-conference.ts
+++ b/src/features/registration/actions/register-for-conference.ts
@@ -6,6 +6,7 @@ import { getPayload, ValidationError } from "payload";
 import type { ActionResponse } from "@/shared/types/action";
 import {
   CONFERENCE_REGISTRATION_ERROR_CODES,
+  isConferenceRegistrationErrorCode,
   type ConferenceRegistrationErrorCode,
 } from "@/shared/constants/conference-registration-error-codes";
 import type { Locale } from "@/shared/lib/next-intl/types";
@@ -53,10 +54,14 @@ export async function registerForConferenceAction(
 
   if (createRegistrationError) {
     if (createRegistrationError instanceof ValidationError) {
-      const errorCode =
-        (createRegistrationError.data.errors[0]
-          .message as ConferenceRegistrationErrorCode) ||
-        CONFERENCE_REGISTRATION_ERROR_CODES.PAYLOAD_VALIDATION;
+      // Payload's message is an arbitrary string: our validators return codes,
+      // but Payload generates its own messages too. Narrow rather than assert,
+      // so anything unrecognised becomes PAYLOAD_VALIDATION instead of flowing
+      // on as a code the client has no case for.
+      const rawMessage = createRegistrationError.data.errors[0]?.message;
+      const errorCode = isConferenceRegistrationErrorCode(rawMessage)
+        ? rawMessage
+        : CONFERENCE_REGISTRATION_ERROR_CODES.PAYLOAD_VALIDATION;
 
       return {
         data: null,

--- a/src/features/registration/actions/register-for-datathon-individual.ts
+++ b/src/features/registration/actions/register-for-datathon-individual.ts
@@ -6,6 +6,7 @@ import { getPayload, ValidationError } from "payload";
 import type { ActionResponse } from "@/shared/types/action";
 import {
   DATATHON_REGISTRATION_ERROR_CODES,
+  isDatathonRegistrationErrorCode,
   type DatathonRegistrationErrorCode,
 } from "@/shared/constants/datathon-registration-error-codes";
 import type { Locale } from "@/shared/lib/next-intl/types";
@@ -51,13 +52,16 @@ export async function registerForDatathonIndividualAction(
 
   if (createRegistrationError) {
     if (createRegistrationError instanceof ValidationError) {
+      // Narrow rather than assert: Payload generates its own messages too,
+      // and an unrecognised one must not flow on as a code.
+      const rawMessage = createRegistrationError.data.errors[0]?.message;
+
       return {
         data: null,
         error: {
-          code:
-            (createRegistrationError.data.errors[0]
-              .message as DatathonRegistrationErrorCode) ||
-            DATATHON_REGISTRATION_ERROR_CODES.PAYLOAD_VALIDATION,
+          code: isDatathonRegistrationErrorCode(rawMessage)
+            ? rawMessage
+            : DATATHON_REGISTRATION_ERROR_CODES.PAYLOAD_VALIDATION,
           message:
             "Validation error while creating registration for Datathon (individual).",
         },

--- a/src/features/registration/actions/register-for-datathon.ts
+++ b/src/features/registration/actions/register-for-datathon.ts
@@ -6,6 +6,7 @@ import { getPayload, ValidationError } from "payload";
 import type { ActionResponse } from "@/shared/types/action";
 import {
   DATATHON_REGISTRATION_ERROR_CODES,
+  isDatathonRegistrationErrorCode,
   type DatathonRegistrationErrorCode,
 } from "@/shared/constants/datathon-registration-error-codes";
 import type { Locale } from "@/shared/lib/next-intl/types";
@@ -50,13 +51,16 @@ export async function registerForDatathonAction(
 
   if (createRegistrationError) {
     if (createRegistrationError instanceof ValidationError) {
+      // Narrow rather than assert: Payload generates its own messages too,
+      // and an unrecognised one must not flow on as a code.
+      const rawMessage = createRegistrationError.data.errors[0]?.message;
+
       return {
         data: null,
         error: {
-          code:
-            (createRegistrationError.data.errors[0]
-              .message as DatathonRegistrationErrorCode) ||
-            DATATHON_REGISTRATION_ERROR_CODES.PAYLOAD_VALIDATION,
+          code: isDatathonRegistrationErrorCode(rawMessage)
+            ? rawMessage
+            : DATATHON_REGISTRATION_ERROR_CODES.PAYLOAD_VALIDATION,
           message: "Validation error while creating registration for Datathon.",
         },
       };

--- a/src/shared/constants/conference-registration-error-codes.ts
+++ b/src/shared/constants/conference-registration-error-codes.ts
@@ -1,7 +1,11 @@
 /**
- * Single vocabulary for conference registration: zod, Payload validators,
- * and the server action all use these string codes. No paths or i18n —
- * the client maps codes to fields and translations.
+ * The error vocabulary for conference registration, spoken by the Payload field
+ * validators and passed through by the server action. The client maps a code to
+ * a field and a translation key.
+ *
+ * Note zod does not use these codes: the schema emits translation keys directly,
+ * because it runs on the client where it can resolve them. So a given rule can
+ * surface either way depending on which layer rejected it.
  */
 export const CONFERENCE_REGISTRATION_ERROR_CODES = {
   SCHEMA_VALIDATION: "SCHEMA_VALIDATION",

--- a/src/shared/constants/datathon-registration-error-codes.ts
+++ b/src/shared/constants/datathon-registration-error-codes.ts
@@ -1,7 +1,11 @@
 /**
- * Single vocabulary for Datathon registration: zod, Payload validators,
- * and the server action all use these string codes. No paths or i18n —
- * the client maps codes to fields and translations.
+ * The error vocabulary for Datathon registration, spoken by the Payload field
+ * validators and passed through by the server action. The client maps a code to
+ * a field and a translation key.
+ *
+ * Note zod does not use these codes: the schema emits translation keys directly,
+ * because it runs on the client where it can resolve them. So a given rule can
+ * surface either way depending on which layer rejected it.
  */
 export const DATATHON_REGISTRATION_ERROR_CODES = {
   SCHEMA_VALIDATION: "SCHEMA_VALIDATION",

--- a/src/shared/tests/registration-error-codes.test.ts
+++ b/src/shared/tests/registration-error-codes.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CONFERENCE_REGISTRATION_ERROR_CODES,
+  isConferenceRegistrationErrorCode,
+} from "@/shared/constants/conference-registration-error-codes";
+import {
+  DATATHON_REGISTRATION_ERROR_CODES,
+  isDatathonRegistrationErrorCode,
+} from "@/shared/constants/datathon-registration-error-codes";
+
+/**
+ * #151: the actions used to assert Payload's error message was a code. These
+ * guards are what replaced the cast, so they need to actually reject the
+ * messages Payload generates on its own.
+ */
+describe.each([
+  [
+    "conference",
+    CONFERENCE_REGISTRATION_ERROR_CODES,
+    isConferenceRegistrationErrorCode,
+  ],
+  [
+    "datathon",
+    DATATHON_REGISTRATION_ERROR_CODES,
+    isDatathonRegistrationErrorCode,
+  ],
+] as const)("%s error codes", (_label, codes, isErrorCode) => {
+  it("accepts every declared code", () => {
+    for (const code of Object.values(codes)) {
+      expect(isErrorCode(code)).toBe(true);
+    }
+  });
+
+  it.each([
+    "The following field is invalid: email",
+    "ValidationError",
+    "",
+    "unique_email",
+    "SOME_CODE_WE_DO_NOT_DECLARE",
+  ])("rejects %o, which Payload could produce", (message) => {
+    expect(isErrorCode(message)).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #151

## What changed

All three registration actions did this:

```ts
const errorCode =
  (createRegistrationError.data.errors[0].message as ConferenceRegistrationErrorCode) ||
  CONFERENCE_REGISTRATION_ERROR_CODES.PAYLOAD_VALIDATION;
```

`message` is an arbitrary string. Our validators return codes, but Payload generates its own messages too — so a message that was not a code satisfied the compiler, flowed through to the client's switch, and matched nothing. The `||` fallback only caught the empty string.

The guards written for exactly this had **zero call sites**. They are now used:

```ts
const rawMessage = createRegistrationError.data.errors[0]?.message;
const errorCode = isConferenceRegistrationErrorCode(rawMessage)
  ? rawMessage
  : CONFERENCE_REGISTRATION_ERROR_CODES.PAYLOAD_VALIDATION;
```

## Doc comments

Both error-code files claimed "zod, Payload validators, and the server action all use these string codes". zod does not — the schema emits translation keys directly, because it runs on the client where it can resolve them. Corrected, since the claim is what makes the layering confusing to read.

## How to verify

`pnpm test` — twelve tests covering both guards: every declared code is accepted, and messages Payload could plausibly generate (`"The following field is invalid: email"`, `"ValidationError"`, `""`, wrong-case, undeclared codes) are rejected.

## Risk and rollout

Behaviour changes only where a non-code message previously slipped through, which produced the generic unknown error anyway once it failed to match a case. Now it becomes `PAYLOAD_VALIDATION` deliberately, which the client does handle.

Note this pairs with #148: that made the client handle every code exhaustively, and this makes sure only real codes reach it.