### PR TITLE
refactor(core): give each content source its own cache tag

### DIFF
--- a/src/features/landing/queries/get-about-page-data.ts
+++ b/src/features/landing/queries/get-about-page-data.ts
@@ -4,12 +4,16 @@ import { cacheTag } from "next/cache";
 import config from "@payload-config";
 import { getPayload } from "payload";
 
-import { LANDING_TAG } from "@/shared/constants/cache-tags";
+import {
+  AMBASSADORS_TAG,
+  EDITIONS_TAG,
+  MEDIA_TAG,
+} from "@/shared/constants/cache-tags";
 import type { Locale } from "@/shared/lib/next-intl/types";
 
 export async function getAboutPageData(locale: Locale) {
   "use cache";
-  cacheTag(LANDING_TAG);
+  cacheTag(AMBASSADORS_TAG, EDITIONS_TAG, MEDIA_TAG);
 
   const payload = await getPayload({ config });
 

--- a/src/features/landing/queries/get-conference-page-data.ts
+++ b/src/features/landing/queries/get-conference-page-data.ts
@@ -4,12 +4,18 @@ import { cacheTag } from "next/cache";
 import config from "@payload-config";
 import { getPayload } from "payload";
 
-import { LANDING_TAG } from "@/shared/constants/cache-tags";
+import {
+  EDITIONS_TAG,
+  EVENTS_TAG,
+  MEDIA_TAG,
+  SCHEDULES_TAG,
+  SPEAKERS_TAG,
+} from "@/shared/constants/cache-tags";
 import type { Locale } from "@/shared/lib/next-intl/types";
 
 export async function getConferencePageData(locale: Locale) {
   "use cache";
-  cacheTag(LANDING_TAG);
+  cacheTag(EDITIONS_TAG, EVENTS_TAG, MEDIA_TAG, SCHEDULES_TAG, SPEAKERS_TAG);
 
   const payload = await getPayload({ config });
 

--- a/src/features/landing/queries/get-datathon-page-data.ts
+++ b/src/features/landing/queries/get-datathon-page-data.ts
@@ -4,12 +4,18 @@ import { cacheTag } from "next/cache";
 import config from "@payload-config";
 import { getPayload } from "payload";
 
-import { LANDING_TAG } from "@/shared/constants/cache-tags";
+import {
+  EDITIONS_TAG,
+  EVENTS_TAG,
+  MEDIA_TAG,
+  SCHEDULES_TAG,
+  SPEAKERS_TAG,
+} from "@/shared/constants/cache-tags";
 import type { Locale } from "@/shared/lib/next-intl/types";
 
 export async function getDatathonPageData(locale: Locale) {
   "use cache";
-  cacheTag(LANDING_TAG);
+  cacheTag(EDITIONS_TAG, EVENTS_TAG, MEDIA_TAG, SCHEDULES_TAG, SPEAKERS_TAG);
 
   const payload = await getPayload({ config });
 

--- a/src/features/landing/queries/get-home-page-data.ts
+++ b/src/features/landing/queries/get-home-page-data.ts
@@ -4,12 +4,18 @@ import { cacheTag } from "next/cache";
 import config from "@payload-config";
 import { getPayload } from "payload";
 
-import { LANDING_TAG } from "@/shared/constants/cache-tags";
+import {
+  AMBASSADORS_TAG,
+  EDITIONS_TAG,
+  EVENTS_TAG,
+  MEDIA_TAG,
+  SPONSORS_TAG,
+} from "@/shared/constants/cache-tags";
 import type { Locale } from "@/shared/lib/next-intl/types";
 
 export async function getHomePageData(locale: Locale) {
   "use cache";
-  cacheTag(LANDING_TAG);
+  cacheTag(AMBASSADORS_TAG, EDITIONS_TAG, EVENTS_TAG, MEDIA_TAG, SPONSORS_TAG);
 
   const payload = await getPayload({ config });
 

--- a/src/features/landing/queries/get-nextgen-page-data.ts
+++ b/src/features/landing/queries/get-nextgen-page-data.ts
@@ -4,12 +4,18 @@ import { cacheTag } from "next/cache";
 import config from "@payload-config";
 import { getPayload } from "payload";
 
-import { LANDING_TAG } from "@/shared/constants/cache-tags";
+import {
+  EDITIONS_TAG,
+  EVENTS_TAG,
+  MEDIA_TAG,
+  SCHEDULES_TAG,
+  SPEAKERS_TAG,
+} from "@/shared/constants/cache-tags";
 import type { Locale } from "@/shared/lib/next-intl/types";
 
 export async function getNextgenPageData(locale: Locale) {
   "use cache";
-  cacheTag(LANDING_TAG);
+  cacheTag(EDITIONS_TAG, EVENTS_TAG, MEDIA_TAG, SCHEDULES_TAG, SPEAKERS_TAG);
 
   const payload = await getPayload({ config });
 

--- a/src/features/landing/queries/get-terms-and-conditions-page-data.ts
+++ b/src/features/landing/queries/get-terms-and-conditions-page-data.ts
@@ -4,12 +4,12 @@ import { cacheTag } from "next/cache";
 import config from "@payload-config";
 import { getPayload } from "payload";
 
-import { LANDING_TAG } from "@/shared/constants/cache-tags";
+import { TERMS_AND_CONDITIONS_TAG } from "@/shared/constants/cache-tags";
 import type { Locale } from "@/shared/lib/next-intl/types";
 
 export async function getTermsAndConditionsPageData(locale: Locale) {
   "use cache";
-  cacheTag(LANDING_TAG);
+  cacheTag(TERMS_AND_CONDITIONS_TAG);
 
   const payload = await getPayload({ config });
 

--- a/src/shared/constants/cache-tags.ts
+++ b/src/shared/constants/cache-tags.ts
@@ -1,2 +1,17 @@
-export const LANDING_TAG = "landing";
-export const BLOG_TAG = "blog";
+/**
+ * One tag per content source. A query tags itself with everything it reads; a
+ * collection revalidates only its own tag. That way editing a sponsor no longer
+ * flushes the conference page.
+ *
+ * A query fetching with `depth: 1` populates uploads, so it must also tag
+ * MEDIA_TAG — replacing an image changes that query's output without touching
+ * the collection it queried.
+ */
+export const EDITIONS_TAG = "editions";
+export const EVENTS_TAG = "events";
+export const SPEAKERS_TAG = "speakers";
+export const SCHEDULES_TAG = "schedules";
+export const SPONSORS_TAG = "sponsors";
+export const AMBASSADORS_TAG = "ambassadors";
+export const MEDIA_TAG = "media";
+export const TERMS_AND_CONDITIONS_TAG = "terms-and-conditions";

--- a/src/shared/lib/payload/collections/ambassadors.ts
+++ b/src/shared/lib/payload/collections/ambassadors.ts
@@ -1,5 +1,5 @@
 import type { CollectionConfig } from "payload";
-import { LANDING_TAG } from "../../../constants/cache-tags.ts";
+import { AMBASSADORS_TAG } from "../../../constants/cache-tags.ts";
 import { revalidateCache } from "../../../utils/revalidate-cache.ts";
 import { isAdminOrEditor } from "../utils/is-admin-or-editor.ts";
 
@@ -76,7 +76,11 @@ export const Ambassadors: CollectionConfig = {
   hooks: {
     afterChange: [
       async ({ req }) => {
-        await revalidateCache({ req, source: "ambassadors", tag: LANDING_TAG });
+        await revalidateCache({
+          req,
+          source: "ambassadors",
+          tag: AMBASSADORS_TAG,
+        });
       },
     ],
   },

--- a/src/shared/lib/payload/collections/editions.ts
+++ b/src/shared/lib/payload/collections/editions.ts
@@ -1,5 +1,5 @@
 import type { CollectionConfig } from "payload";
-import { LANDING_TAG } from "../../../constants/cache-tags.ts";
+import { EDITIONS_TAG } from "../../../constants/cache-tags.ts";
 import { revalidateCache } from "../../../utils/revalidate-cache.ts";
 import { isAdminOrEditor } from "../utils/is-admin-or-editor.ts";
 
@@ -41,7 +41,7 @@ export const Editions: CollectionConfig = {
   hooks: {
     afterChange: [
       async ({ req }) => {
-        await revalidateCache({ req, source: "editions", tag: LANDING_TAG });
+        await revalidateCache({ req, source: "editions", tag: EDITIONS_TAG });
       },
     ],
   },

--- a/src/shared/lib/payload/collections/events.ts
+++ b/src/shared/lib/payload/collections/events.ts
@@ -1,5 +1,5 @@
 import type { CollectionConfig } from "payload";
-import { LANDING_TAG } from "../../../constants/cache-tags.ts";
+import { EVENTS_TAG } from "../../../constants/cache-tags.ts";
 import { revalidateCache } from "../../../utils/revalidate-cache.ts";
 import { EVENT_TYPES } from "../constants/event-types.ts";
 import { isAdminOrEditor } from "../utils/is-admin-or-editor.ts";
@@ -144,7 +144,7 @@ export const Events: CollectionConfig = {
   hooks: {
     afterChange: [
       async ({ req }) => {
-        await revalidateCache({ req, source: "events", tag: LANDING_TAG });
+        await revalidateCache({ req, source: "events", tag: EVENTS_TAG });
       },
     ],
   },

--- a/src/shared/lib/payload/collections/media.ts
+++ b/src/shared/lib/payload/collections/media.ts
@@ -1,5 +1,5 @@
 import type { CollectionConfig } from "payload";
-import { LANDING_TAG } from "../../../constants/cache-tags.ts";
+import { MEDIA_TAG } from "../../../constants/cache-tags.ts";
 import { revalidateCache } from "../../../utils/revalidate-cache.ts";
 import { isAdminOrEditor } from "../utils/is-admin-or-editor.ts";
 
@@ -32,7 +32,7 @@ export const Media: CollectionConfig = {
   hooks: {
     afterChange: [
       async ({ req }) => {
-        await revalidateCache({ req, source: "media", tag: LANDING_TAG });
+        await revalidateCache({ req, source: "media", tag: MEDIA_TAG });
       },
     ],
   },

--- a/src/shared/lib/payload/collections/schedules.ts
+++ b/src/shared/lib/payload/collections/schedules.ts
@@ -1,5 +1,5 @@
 import type { CollectionConfig, PayloadRequest } from "payload";
-import { LANDING_TAG } from "../../../constants/cache-tags.ts";
+import { SCHEDULES_TAG } from "../../../constants/cache-tags.ts";
 import { revalidateCache } from "../../../utils/revalidate-cache.ts";
 import { SCHEDULE_TYPES } from "../constants/schedule-types.ts";
 import { isAdminOrEditor } from "../utils/is-admin-or-editor.ts";
@@ -156,7 +156,7 @@ export const Schedules: CollectionConfig = {
   hooks: {
     afterChange: [
       async ({ req }) => {
-        await revalidateCache({ req, source: "schedules", tag: LANDING_TAG });
+        await revalidateCache({ req, source: "schedules", tag: SCHEDULES_TAG });
       },
     ],
   },

--- a/src/shared/lib/payload/collections/speakers.ts
+++ b/src/shared/lib/payload/collections/speakers.ts
@@ -1,5 +1,5 @@
 import type { CollectionConfig } from "payload";
-import { LANDING_TAG } from "../../../constants/cache-tags.ts";
+import { SPEAKERS_TAG } from "../../../constants/cache-tags.ts";
 import { revalidateCache } from "../../../utils/revalidate-cache.ts";
 import { isAdminOrEditor } from "../utils/is-admin-or-editor.ts";
 
@@ -69,7 +69,7 @@ export const Speakers: CollectionConfig = {
   hooks: {
     afterChange: [
       async ({ req }) => {
-        await revalidateCache({ req, source: "speakers", tag: LANDING_TAG });
+        await revalidateCache({ req, source: "speakers", tag: SPEAKERS_TAG });
       },
     ],
   },

--- a/src/shared/lib/payload/collections/sponsors.ts
+++ b/src/shared/lib/payload/collections/sponsors.ts
@@ -1,5 +1,5 @@
 import type { CollectionConfig } from "payload";
-import { LANDING_TAG } from "../../../constants/cache-tags.ts";
+import { SPONSORS_TAG } from "../../../constants/cache-tags.ts";
 import { revalidateCache } from "../../../utils/revalidate-cache.ts";
 import { SPONSOR_TIERS } from "../constants/sponsor-tiers.ts";
 import { isAdminOrEditor } from "../utils/is-admin-or-editor.ts";
@@ -54,7 +54,7 @@ export const Sponsors: CollectionConfig = {
   hooks: {
     afterChange: [
       async ({ req }) => {
-        await revalidateCache({ req, source: "sponsors", tag: LANDING_TAG });
+        await revalidateCache({ req, source: "sponsors", tag: SPONSORS_TAG });
       },
     ],
   },

--- a/src/shared/lib/payload/globals/terms-and-conditions.ts
+++ b/src/shared/lib/payload/globals/terms-and-conditions.ts
@@ -1,7 +1,7 @@
 import type { GlobalConfig } from "payload";
 
 import { isAdminOrEditor } from "../utils/is-admin-or-editor";
-import { LANDING_TAG } from "../../../constants/cache-tags";
+import { TERMS_AND_CONDITIONS_TAG } from "../../../constants/cache-tags";
 import { revalidateCache } from "../../../utils/revalidate-cache";
 
 export const TermsAndConditions: GlobalConfig = {
@@ -27,7 +27,7 @@ export const TermsAndConditions: GlobalConfig = {
         await revalidateCache({
           req,
           source: "terms-and-conditions",
-          tag: LANDING_TAG,
+          tag: TERMS_AND_CONDITIONS_TAG,
         });
       },
     ],

--- a/src/shared/tests/cache-tags.test.ts
+++ b/src/shared/tests/cache-tags.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import * as cacheTags from "@/shared/constants/cache-tags";
+
+const QUERIES_DIR = "src/features/landing/queries";
+const COLLECTIONS_DIR = "src/shared/lib/payload/collections";
+const GLOBALS_DIR = "src/shared/lib/payload/globals";
+
+function readAll(dir: string) {
+  return readdirSync(dir)
+    .filter((file) => file.endsWith(".ts"))
+    .map((file) => readFileSync(join(dir, file), "utf8"))
+    .join("\n");
+}
+
+const consumers = readAll(QUERIES_DIR);
+const producers = `${readAll(COLLECTIONS_DIR)}\n${readAll(GLOBALS_DIR)}`;
+const TAG_NAMES = Object.keys(cacheTags);
+
+/**
+ * #152: BLOG_TAG was declared and never used, and every query shared one
+ * LANDING_TAG so editing any content flushed every page. These assertions keep
+ * the vocabulary honest — a tag nothing reads, or nothing revalidates, is a bug.
+ */
+describe("cache tags", () => {
+  it("declares a tag per content source, with no duplicate values", () => {
+    const values = Object.values(cacheTags);
+
+    expect(new Set(values).size).toBe(values.length);
+  });
+
+  it.each(TAG_NAMES)("%s is read by at least one query", (tag) => {
+    expect(consumers).toContain(tag);
+  });
+
+  it.each(TAG_NAMES)(
+    "%s is revalidated by at least one collection or global",
+    (tag) => {
+      expect(producers).toContain(tag);
+    },
+  );
+
+  it("leaves no query on a catch-all tag", () => {
+    expect(consumers).not.toContain("LANDING_TAG");
+  });
+});


### PR DESCRIPTION
Closes #152

## What changed

All six landing queries shared one `LANDING_TAG`, and eight collections and globals revalidated it. Editing a single sponsor flushed the cache for every page in every locale, including pages that do not show sponsors. `BLOG_TAG` was declared and never used.

There is now one tag per content source. Each query tags itself with what it reads; each collection revalidates only its own.

| Query | Tags |
| --- | --- |
| home | editions, events, ambassadors, sponsors, media |
| about | editions, ambassadors, media |
| conference / datathon / nextgen | editions, events, speakers, schedules, media |
| terms and conditions | terms-and-conditions |

So a sponsor edit now invalidates the home page only, and a schedule edit leaves home and about untouched.

## Why media is on almost everything

Queries fetching with `depth: 1` populate uploads — ambassadors and sponsors on home, speakers and schedules on the event pages. Replacing an image changes those queries' output without touching the collection they queried, so they have to tag `MEDIA_TAG` or a new logo would not appear.

That means a media edit still invalidates broadly. Making it precise would need per-document tags, which is a larger change than this issue.

## Keeping the vocabulary honest

`src/shared/tests/cache-tags.test.ts` asserts every declared tag has **at least one producer and one consumer**, plus no duplicate values and no query left on a catch-all. `BLOG_TAG` would have failed both halves.

Verified by adding an orphan tag: two tests fail, one for the missing consumer and one for the missing producer.

## How to verify

1. `pnpm test` — 57 tests.
2. `pnpm build` passes against a local Postgres.
3. End to end: edit a sponsor in the admin panel and confirm the home page updates while a conference page served from cache does not.

Point 3 is the one I could not check here — it needs a deployed environment with the revalidate route reachable and `REVALIDATE_TOKEN` set. Worth doing on the preview deployment before merging.

## Risk and rollout

The revalidation path is unchanged in shape — hooks still POST to `/api/revalidate`, which still calls `revalidateTag`. Only the tag strings differ.

The failure mode if a tag is wrong is stale content rather than an error, which is quiet. That is what the producer/consumer test is for, but it cannot prove a query tags *everything* it reads — only that no tag is orphaned.