### PR TITLE
fix(next-intl): stop hreflang Link header from breaking Safari

### DIFF
--- a/src/shared/lib/next-intl/routing.ts
+++ b/src/shared/lib/next-intl/routing.ts
@@ -5,6 +5,28 @@ import { LOCALES } from "@/shared/lib/next-intl/locales";
 export const routing = defineRouting({
   locales: LOCALES,
   defaultLocale: "es",
+  /**
+   * TEMPORARY — works around a Next.js bug, not a decision about hreflang.
+   * Revert to the default (`true`) once the upstream fix lands.
+   *
+   * On every revalidation of a prerendered route, Next appends the proxy's
+   * `Link` header to the one already stored with the cached entry instead of
+   * replacing it, so the hreflang set compounds without bound. Measured on
+   * 2026-09-01: /es carried the same three-entry set 340 times, 67 KB of
+   * response headers. At `x-nextjs-stale-time: 300` that is ~28 hours of
+   * uptime, and it keeps growing. Chrome tolerates the size; Safari rejects the
+   * response outright and reports it as "the page's address isn't valid".
+   *
+   * next-intl is not at fault — its own header is clean. Hitting the app
+   * directly on localhost shows two `Link` headers: the proxy's, with one copy,
+   * and the cached prerender's, with N copies and Next's own preconnect/preload
+   * hints at the tail. Same merge path as vercel/next.js#69000.
+   *
+   * There is no userland fix: the header is assembled inside the caching layer,
+   * so the only other lever is giving up ISR. `sitemap.ts` still emits hreflang
+   * for every route, so search engines keep a complete signal meanwhile.
+   */
+  alternateLinks: false,
   pathnames: {
     "/": {
       en: "/",


### PR DESCRIPTION
Closes #176

## What changed

Sets `alternateLinks: false` in `routing.ts`, so next-intl stops attaching the `hreflang` alternates as a `Link` response header.

This is a **temporary workaround for a Next.js bug**, not a decision about how we do `hreflang`. On every revalidation of a prerendered route, Next appends the proxy's `Link` header to the value already stored with the cached entry instead of replacing it, so the set compounds without bound — `/es` was serving the same three entries 340 times, in 67 KB of response headers. Chrome tolerates that; Safari rejects the response and reports it as "the page's address isn't valid".

next-intl is not at fault, and neither is our config: hitting the app directly on `localhost:3000` shows two `Link` headers, the proxy's with a single clean copy and the cached prerender's with N copies plus Next's own `preconnect`/`preload` hints at the tail. Full evidence is in #176.

Disabling the header is the only lever available in userland — the value is assembled inside the caching layer, so the alternative is giving up ISR. `sitemap.ts` already emits `hreflang` for every route, which is one of the mechanisms search engines accept, so the signal stays complete.

The config carries a comment recording the cause, the measurements, and the instruction to revert to the default once upstream is fixed.

## How to verify

1. After deploying, purge the route cache — a redeploy alone may not evict it, since the entries carry `stale-while-revalidate=31535100`. Restart the container or hit the revalidate endpoint.
2. Run `curl -sSI --http1.1 https://wids.espol.edu.ec/es | awk '{n+=length($0)+2} END{print n" bytes"}'`. It should report a few hundred bytes, not tens of thousands.
3. Confirm no `link:` header with repeated `hreflang` entries: `curl -sSI --http1.1 https://wids.espol.edu.ec/es | grep -i '^link:'`.
4. Open `https://wids.espol.edu.ec/es` and `/en` in **Safari**. Both should load.
5. Confirm `hreflang` is still published: `curl -sS https://wids.espol.edu.ec/sitemap.xml | grep -c hreflang` should return 16.

## Risk and rollout

Low and self-contained — one config flag, no schema, no migration, no env vars.

The only behavioural change is that `hreflang` is no longer duplicated in a response header; it continues to be published in `sitemap.xml`. No runtime, routing, or rendering behaviour changes.

**Requires a cache purge after deploy** to take effect on already-poisoned entries (step 1 above).

Revert path is a one-line change back to the default.

## Checklist

- [x] Title follows Conventional Commits and matches the work
- [x] Branch is named `type/wids-<issue-number>`
- [x] Linked issue above, so it closes on merge
- [x] Everything is in English
- [x] `pnpm lint`, `pnpm typecheck` and `pnpm test` all pass
- [ ] Preview deployment builds successfully
- [x] Acceptance criteria on the linked issue are met
