### PR TITLE
fix(sitemap): resolve hreflang URLs through the locale prefix

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,59 +1,58 @@
 import type { MetadataRoute } from "next";
 
+import { getPathname } from "@/shared/lib/next-intl/navigation";
 import { routing } from "@/shared/lib/next-intl/routing";
+import type { Locale } from "@/shared/lib/next-intl/types";
 import { getAppUrl } from "@/shared/utils/get-app-url";
 
-import { getBlogPosts } from "@/features/blog/queries/get-blog-posts";
+type Pathname = keyof typeof routing.pathnames;
+
+/**
+ * Routes with no `[param]` segment, which are the only ones that name a URL on
+ * their own. `/blog/[slug]` is a template; posts are not listed in the sitemap.
+ */
+type StaticPathname = Exclude<Pathname, `${string}[${string}`>;
 
 const SITEMAP_EXCLUDED_PATHNAMES = new Set<string>(["/conference/attendance"]);
 
-/** `/blog/[slug]` is a template, not a URL — its posts are added separately. */
-const isDynamicPathname = (pathname: string) => pathname.includes("[");
+const isStaticPathname = (pathname: Pathname): pathname is StaticPathname =>
+  !pathname.includes("[");
 
-export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const staticEntries: MetadataRoute.Sitemap = Object.entries(routing.pathnames)
-    .filter(
-      ([key]) =>
-        !SITEMAP_EXCLUDED_PATHNAMES.has(key) && !isDynamicPathname(key),
-    )
-    .map(([, pathname]) => ({
-      url: new URL(pathname.es, getAppUrl()).toString(),
+/**
+ * Resolves a route to its absolute URL in one locale.
+ *
+ * Goes through `getPathname` rather than reading `routing.pathnames` directly.
+ * The raw map holds unprefixed paths, but `localePrefix` is "always", so every
+ * real URL carries an `/en` or `/es` segment. Building the URLs by hand omitted
+ * it, and unprefixed paths redirect to the *default* locale — so every English
+ * alternate resolved to the Spanish page, and both alternates for `/` pointed
+ * at the same URL.
+ */
+function toUrl(pathname: StaticPathname, locale: Locale) {
+  return new URL(
+    getPathname({ href: pathname, locale }),
+    getAppUrl(),
+  ).toString();
+}
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return (Object.keys(routing.pathnames) as Pathname[])
+    .filter(isStaticPathname)
+    .filter((pathname) => !SITEMAP_EXCLUDED_PATHNAMES.has(pathname))
+    .map((pathname) => ({
+      url: toUrl(pathname, routing.defaultLocale),
       lastModified: new Date(),
-      changeFrequency: pathname.es === "/" ? "weekly" : "monthly",
-      priority: pathname.es === "/" ? 1 : 0.8,
+      changeFrequency: pathname === "/" ? "weekly" : "monthly",
+      priority: pathname === "/" ? 1 : 0.8,
       alternates: {
         languages: {
-          en: new URL(pathname.en, getAppUrl()).toString(),
-          es: new URL(pathname.es, getAppUrl()).toString(),
+          ...Object.fromEntries(
+            routing.locales.map((locale) => [locale, toUrl(pathname, locale)]),
+          ),
+          // Marks the URL for readers whose language we do not publish. That is
+          // the default locale, not a separate unprefixed URL — none exists.
+          "x-default": toUrl(pathname, routing.defaultLocale),
         },
       },
     }));
-
-  // Slugs are localized, so each locale is fetched and the pair matched by id.
-  const [spanishPosts, englishPosts] = await Promise.all([
-    getBlogPosts("es"),
-    getBlogPosts("en"),
-  ]);
-
-  const englishSlugById = new Map(
-    englishPosts.map((post) => [post.id, post.slug]),
-  );
-
-  const postEntries: MetadataRoute.Sitemap = spanishPosts.map((post) => ({
-    url: new URL(`/blog/${post.slug}`, getAppUrl()).toString(),
-    lastModified: new Date(post.updatedAt),
-    changeFrequency: "monthly",
-    priority: 0.6,
-    alternates: {
-      languages: {
-        en: new URL(
-          `/en/blog/${englishSlugById.get(post.id) ?? post.slug}`,
-          getAppUrl(),
-        ).toString(),
-        es: new URL(`/blog/${post.slug}`, getAppUrl()).toString(),
-      },
-    },
-  }));
-
-  return [...staticEntries, ...postEntries];
 }


### PR DESCRIPTION
Closes #178

## What changed

The sitemap built its URLs from `routing.pathnames` directly. That map holds **unprefixed** paths, but `localePrefix` is `always`, so every URL it advertised redirected to the default locale — every `hreflang="en"` entry resolved to a Spanish page, and both alternates for `/` pointed at the same URL.

URLs now resolve through next-intl's `getPathname`, so the locale-prefix strategy stays the single source of truth and a later change to `localePrefix` cannot silently reintroduce this. `x-default` is added; it was missing from every entry.

Two accompanying changes:

- **Blog posts are no longer listed.** This drops the two `getBlogPosts` calls and the cross-locale slug matching, so the route is now pure and touches no database.
- **`/blog/[slug]` is excluded at the type level**, not only by a runtime filter, so `getPathname` cannot be called with a template that still needs params.

This bug is pre-existing, but it became consequential with #176: that change disabled the `Link` response header, which carried correct prefixed URLs. The sitemap is now the only `hreflang` mechanism, so it has to be right.

### Before / after

```
before   <loc>https://wids.espol.edu.ec/nosotros</loc>          307 → /es/nosotros
           hreflang="en"  https://wids.espol.edu.ec/about       307 → /es/nosotros   ← Spanish
           hreflang="es"  https://wids.espol.edu.ec/nosotros    307 → /es/nosotros
           (no x-default)

after    <loc>https://wids.espol.edu.ec/es/nosotros</loc>       200
           hreflang="en"        https://wids.espol.edu.ec/en/about      200
           hreflang="es"        https://wids.espol.edu.ec/es/nosotros   200
           hreflang="x-default" https://wids.espol.edu.ec/es/nosotros   200
```

## How to verify

1. `curl -sS https://wids.espol.edu.ec/sitemap.xml | head -14` — every `href` carries an `/en` or `/es` segment, and each `<url>` has three alternates including `x-default`.
2. Take any `hreflang="en"` href and confirm it returns 200 without redirecting:
   `curl -sS -o /dev/null -w "%{http_code} -> %{redirect_url}\n" https://wids.espol.edu.ec/en/about`
3. Confirm no blog post URLs appear: `curl -sS https://wids.espol.edu.ec/sitemap.xml | grep -c '/blog/'` should return 0.
4. Confirm the attendance route is still excluded: `grep -c 'attendance'` on the same output should return 0.

## Risk and rollout

Low. One file, no schema, no migration, no env vars. Output is metadata only — no runtime, routing, or rendering behaviour changes.

Removing blog posts from the sitemap means new posts are no longer submitted to search engines through it; they remain crawlable via links from `/blog`. This was a deliberate scope decision, not a side effect.

**Not verified by execution.** `getPathname` imports `next/navigation`, which Vitest cannot resolve outside Next's `react-server` condition, so the route could not be run in a unit test; `pnpm build` needs Postgres and runs migrations. This is verified by typecheck and review only — please confirm step 1 and 2 against the preview deployment before merging.

## Checklist

- [x] Title follows Conventional Commits and matches the work
- [x] Branch is named `type/wids-<issue-number>`
- [x] Linked issue above, so it closes on merge
- [x] Everything is in English
- [x] `pnpm lint`, `pnpm typecheck` and `pnpm test` all pass
- [ ] Preview deployment builds successfully
- [ ] Acceptance criteria on the linked issue are met
