### PR TITLE
refactor(media): remove the now-empty media prefix option

### DIFF
--- a/docs/adr/0001-serve-media-from-a-private-bucket.md
+++ b/docs/adr/0001-serve-media-from-a-private-bucket.md
@@ -84,25 +84,27 @@ be given real media documents or moved into `public/`.
 
 The `wids/` prefix existed only to namespace a shared public bucket. The private
 bucket holds nothing else, so the prefix earns nothing and is dropped: objects
-are copied to the root, and the collection's `prefix` is `""`.
+live at the root, and the collection declares no `prefix` at all.
 
-This makes the `prefix` column load-bearing in a way `url` is not. Storage keys
-are built as `docPrefix || collectionPrefix`, and `getFilePrefix` resolves
-`docPrefix` from the stored column when no `?prefix=` param is present. Rows
-holding the old `'wids'` would win over the empty collection prefix and keep
-pointing at a path that no longer exists, so the migration clears them and
-resets the column default.
+This made the `prefix` column load-bearing during the cutover in a way `url`
+never was. Storage keys are built as `docPrefix || collectionPrefix`, and
+`getFilePrefix` resolves `docPrefix` from the stored column when no `?prefix=`
+param is present. Rows holding the old `'wids'` would have won over the empty
+collection prefix and kept pointing at a path that no longer exists, so
+migration `20260907_120000_relative_media_urls` clears them and resets the
+column default.
 
-`prefix` is kept as an explicit `""` rather than removed. The plugin only
-injects the `prefix` field when the option is defined, so omitting it would drop
-`media.prefix` from the schema while the column still exists in the database.
-Worse, during a deploy `payload migrate` runs before the new container takes
-over, so a dropped column would break media reads in the still-running old
-release. An empty prefix keeps schema and database aligned and resolves keys to
-the root.
+The cutover shipped with `prefix: ""` rather than removing the option, because
+the plugin only injects the `prefix` field when the option is defined. Omitting
+it drops `media.prefix` from the schema while the column still exists, and
+`payload migrate` runs before the new container takes over during a deploy — so
+a dropped column would have broken media reads in the still-running release. The
+option was removed once that window had passed (#184); with no field injected,
+`getFilePrefix` finds no prefix on the document, returns `""`, and keys resolve
+to the root exactly as before.
 
-Removing the column outright is a reasonable follow-up once the cutover has
-settled, when it can be done on its own rather than during a bucket switch.
+The `media.prefix` column itself is now vestigial. Dropping it is safe only in
+its own deploy, for the same reason: nothing running may still select it.
 
 ## Alternatives considered
 

--- a/payload.config.ts
+++ b/payload.config.ts
@@ -100,20 +100,10 @@ export default buildConfig({
   plugins: [
     s3Storage({
       collections: {
+        // No `prefix`: objects sit at the root of the private bucket, so the
+        // storage key is just the filename. The `wids/` prefix only existed to
+        // namespace the shared public bucket this replaced.
         media: {
-          /**
-           * No prefix: objects sit at the root of the private bucket. The
-           * `wids/` prefix existed only to namespace the shared public bucket.
-           *
-           * Kept as an explicit empty string rather than omitted. The plugin
-           * only injects the `prefix` field when this option is defined, so
-           * omitting it would drop `media.prefix` from the schema while the
-           * column still exists — and would break reads on the running
-           * deployment during the window between `payload migrate` and the new
-           * container taking over. Empty keeps schema and database aligned and
-           * still resolves keys to the bucket root.
-           */
-          prefix: "",
           /**
            * Relative on purpose: same origin, no hostname compiled into the
            * app, and `next/image` treats it as a local path in every

--- a/src/shared/lib/payload/types/payload.ts
+++ b/src/shared/lib/payload/types/payload.ts
@@ -210,7 +210,6 @@ export interface User {
 export interface Media {
   id: number;
   alt: string;
-  prefix?: string | null;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -846,7 +845,6 @@ export interface UsersSelect<T extends boolean = true> {
  */
 export interface MediaSelect<T extends boolean = true> {
   alt?: T;
-  prefix?: T;
   updatedAt?: T;
   createdAt?: T;
   url?: T;


### PR DESCRIPTION
Closes #184

## What changed

`prefix` is gone from the media collection's `s3Storage` options. Objects live at the root of the private bucket, so the option described nothing.

It shipped as `prefix: ""` during the cutover in #181 deliberately, not by oversight: the plugin only injects the `prefix` field when the option is defined, so removing it drops `media.prefix` from the schema — and `payload migrate` runs *before* the new container takes over during a deploy, so the still-running release would have lost a column it selects. That window has passed.

ADR 0001 is updated to record that the anticipated follow-up has happened, and why the column itself still has to wait.

## Storage keys are unchanged

`getFileKey` builds keys as `docPrefix || collectionPrefix`. With no field injected, `getFilePrefix` finds no `prefix` on the document and returns `""`, so keys resolve to the bucket root exactly as they do today. Nothing moves.

## The schema change, and why the column stays for now

The generated types lose two lines:

```diff
 export interface Media {
   id: number;
   alt: string;
-  prefix?: string | null;
```
```diff
 export interface MediaSelect<T extends boolean = true> {
   alt?: T;
-  prefix?: T;
```

That is the whole point of separating this from the column drop. `media.prefix` is now vestigial, but dropping it must be its own deploy — during the deploy of *this* PR the old release is still selecting that column, and during the deploy of a column-drop PR this release will not be. Doing both at once reintroduces exactly the breakage the empty string was avoiding.

## How to verify

1. Deploy, then confirm existing images still render on the site while logged out — listings, detail pages, avatars, and an OG image.
2. `GET /api/media?limit=3` still returns `/api/media/file/<filename>` URLs.
3. Upload a new image in `/admin`, then confirm in the bucket that the object landed at the **root** with no prefix segment, and that it renders.
4. `SELECT prefix FROM media ORDER BY id DESC LIMIT 3;` — still empty; the column is simply no longer written.

## Risk and rollout

Low. No migration runs, no data changes, no object moves. The only change is that Payload stops selecting and writing one column.

Rollback is a revert — the column still exists, so the previous release finds it exactly as before.

## Verification done

- `pnpm lint`, `pnpm typecheck`, `pnpm test` (84 passing) and a full `pnpm build` pass.
- The generated `payload.ts` diff was inspected after normalising it with Prettier: the only change is the two lines above. (The build regenerates that file unformatted, so a raw diff shows ~370 lines of quote and wrapping churn that is not part of this change.)

**Not verified:** anything requiring the bucket. Whether a *new* upload lands at the root is step 3 above and can only be checked against a real deployment.

## Checklist

- [x] Title follows Conventional Commits and matches the work
- [x] Branch is named `type/wids-<issue-number>`
- [x] Linked issue above, so it closes on merge
- [x] Everything is in English
- [x] `pnpm lint`, `pnpm typecheck` and `pnpm test` all pass
- [ ] Preview deployment builds successfully
- [ ] Acceptance criteria on the linked issue are met
