### PR TITLE
refactor(media): drop the vestigial media.prefix column

### DIFF
--- a/docs/adr/0001-serve-media-from-a-private-bucket.md
+++ b/docs/adr/0001-serve-media-from-a-private-bucket.md
@@ -103,8 +103,11 @@ option was removed once that window had passed (#184); with no field injected,
 `getFilePrefix` finds no prefix on the document, returns `""`, and keys resolve
 to the root exactly as before.
 
-The `media.prefix` column itself is now vestigial. Dropping it is safe only in
-its own deploy, for the same reason: nothing running may still select it.
+The `media.prefix` column was then dropped in its own deploy (#186), once the
+running release no longer selected it. That separation was the point: `payload
+migrate` runs before the new container takes over, so dropping a column that the
+serving release still reads would break every media read for the length of a
+deploy.
 
 ## Alternatives considered
 

--- a/src/shared/lib/payload/migrations/20260908_060000_drop_media_prefix.ts
+++ b/src/shared/lib/payload/migrations/20260908_060000_drop_media_prefix.ts
@@ -1,0 +1,32 @@
+import { MigrateUpArgs, MigrateDownArgs, sql } from "@payloadcms/db-postgres";
+
+/**
+ * Drops the vestigial `media.prefix` column.
+ *
+ * Objects live at the root of the private bucket, so there is no prefix to
+ * store. Since the `prefix` option was removed from the collection's
+ * `s3Storage` config, the plugin no longer injects the field: Payload does not
+ * select the column, does not write it, and `getFilePrefix` returns an empty
+ * string, which resolves keys to the bucket root. The column has been dead
+ * weight and schema drift since then.
+ *
+ * This has to be its own deploy. `payload migrate` runs before the new
+ * container takes over, so dropping the column while a release that still
+ * selects it is serving would break every media read for the length of the
+ * deploy. Safe here only because the running release already omits it.
+ */
+
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+    ALTER TABLE "media" DROP COLUMN IF EXISTS "prefix";
+  `);
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  // Restores the state immediately before this migration: the column existed
+  // with an empty default, every row holding ''. Postgres backfills existing
+  // rows from the DEFAULT, so no separate UPDATE is needed.
+  await db.execute(sql`
+    ALTER TABLE "media" ADD COLUMN IF NOT EXISTS "prefix" varchar DEFAULT '';
+  `);
+}

--- a/src/shared/lib/payload/migrations/index.ts
+++ b/src/shared/lib/payload/migrations/index.ts
@@ -6,6 +6,7 @@ import * as migration_20260724_020828_add_conference_attendance_confirmation fro
 import * as migration_20260724_035754_add_attendance_confirmation_job_slug from "./20260724_035754_add_attendance_confirmation_job_slug";
 import * as migration_20260725_012713_add_posts_collection from "./20260725_012713_add_posts_collection";
 import * as migration_20260907_120000_relative_media_urls from "./20260907_120000_relative_media_urls";
+import * as migration_20260908_060000_drop_media_prefix from "./20260908_060000_drop_media_prefix";
 
 export const migrations = [
   {
@@ -47,5 +48,10 @@ export const migrations = [
     up: migration_20260907_120000_relative_media_urls.up,
     down: migration_20260907_120000_relative_media_urls.down,
     name: "20260907_120000_relative_media_urls",
+  },
+  {
+    up: migration_20260908_060000_drop_media_prefix.up,
+    down: migration_20260908_060000_drop_media_prefix.down,
+    name: "20260908_060000_drop_media_prefix",
   },
 ];


### PR DESCRIPTION
Closes #186

## What changed

A migration that drops `media.prefix`.

The column has been dead weight since #185. Objects live at the root of the private bucket, and with the `prefix` option gone from the collection's `s3Storage` config the plugin no longer injects the field — Payload does not select the column, does not write it, and `getFilePrefix` returns an empty string, which resolves keys to the root. What remained was schema drift the next `migrate:create` would have flagged.

`down()` restores the column with the empty default it had immediately before this migration; Postgres backfills existing rows from that default, so no separate `UPDATE` is needed.

## The precondition, and how it was checked

This had to be its own deploy. `payload migrate` runs *before* the new container takes over, so dropping a column that the serving release still selects would break every media read for the length of the deploy.

That is now safe, and I verified it rather than assuming — the deployed API no longer returns the field at all:

```
GET https://wids.espol.edu.ec/api/media?limit=2
{"docs":[{"id":38,"alt":"Taws","updatedAt":…,"url":"/api/media/file/taws.png",
          "thumbnailURL":null,"filename":"taws.png",…}]}
```

No `prefix` key, and `uptime` on `/api/health` confirmed a fresh container from the #185 merge.

**Merge order still matters going forward:** nothing else should be bundled into this deploy.

## How to verify

1. After deploy, confirm images still render on the site while logged out — listings, detail pages, avatars, an OG image.
2. `GET /api/media?limit=3` still returns `/api/media/file/<filename>` URLs.
3. Upload a new image in `/admin`; it should still land at the bucket root and render.
4. `\d media` in psql — no `prefix` column.

## Risk and rollout

Low, but not zero: it is a destructive schema change, so it is worth noting that the data being dropped is a column where every row holds `''`. Nothing is lost.

Rollback is `pnpm payload migrate:down`, which recreates the column with the same type and default. If the deploy needs to be reverted to a pre-#185 release, run that rollback **first** — that release selects the column.

## Verification done

- Applied for real via `pnpm build`, then rolled back with `pnpm payload migrate:down`, then re-applied. The column is dropped, restored as `character varying` with default `''` (matching its prior state), and dropped again.
- Generated `payload.ts` diff is **empty** — #185 already removed `prefix` from the types, which is the concrete confirmation that this migration is purely a database change and that splitting the two deploys was correct.
- `pnpm lint`, `pnpm typecheck`, `pnpm test` (84 passing) and a full `pnpm build` pass.

## Checklist

- [x] Title follows Conventional Commits and matches the work
- [x] Branch is named `type/wids-<issue-number>`
- [x] Linked issue above, so it closes on merge
- [x] Everything is in English
- [x] `pnpm lint`, `pnpm typecheck` and `pnpm test` all pass
- [ ] Preview deployment builds successfully
- [x] Acceptance criteria on the linked issue are met
