### PR TITLE
feat(seo): emit canonical and hreflang link tags on every route

### DIFF
--- a/src/app/(wids)/[locale]/(home)/layout.tsx
+++ b/src/app/(wids)/[locale]/(home)/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { setRequestLocale } from "next-intl/server";
 
+import { getAlternatesMetadata } from "@/shared/lib/next-intl/get-alternates-metadata";
 import type { Locale } from "@/shared/lib/next-intl/types";
 
 export async function generateMetadata({
@@ -25,7 +26,10 @@ export async function generateMetadata({
     },
   };
 
-  return metadata[locale];
+  return {
+    ...metadata[locale],
+    alternates: getAlternatesMetadata("/", locale),
+  };
 }
 
 export default async function Layout({

--- a/src/app/(wids)/[locale]/about/layout.tsx
+++ b/src/app/(wids)/[locale]/about/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { setRequestLocale } from "next-intl/server";
 
+import { getAlternatesMetadata } from "@/shared/lib/next-intl/get-alternates-metadata";
 import type { Locale } from "@/shared/lib/next-intl/types";
 
 export async function generateMetadata({
@@ -23,7 +24,10 @@ export async function generateMetadata({
     },
   };
 
-  return metadata[locale];
+  return {
+    ...metadata[locale],
+    alternates: getAlternatesMetadata("/about", locale),
+  };
 }
 
 export default async function Layout({

--- a/src/app/(wids)/[locale]/blog/[slug]/page.tsx
+++ b/src/app/(wids)/[locale]/blog/[slug]/page.tsx
@@ -9,6 +9,7 @@ import { TypographyH1 } from "@/shared/components/ui/typography-h1";
 import { TypographyParagraph } from "@/shared/components/ui/typography-paragraph";
 import { Link } from "@/shared/lib/next-intl/navigation";
 import type { Locale } from "@/shared/lib/next-intl/types";
+import { getAppUrl } from "@/shared/utils/get-app-url";
 
 import { PostBody } from "@/features/blog/components/post-body";
 import { PostSkeleton } from "@/features/blog/components/post-skeleton";
@@ -35,6 +36,19 @@ export async function generateMetadata({
   return {
     title: `WiDS Guayaquil | ${post.title}`,
     description: post.excerpt,
+    alternates: {
+      /*
+       * Canonical only, no `languages`. Slugs are localized, so an hreflang
+       * pair needs the other locale's slug, and this page has no query that
+       * resolves it. Emitting a pair built from *this* slug would point at a
+       * URL that does not exist — worse than emitting nothing.
+       *
+       * Built by hand rather than with next-intl's `getPathname`, which drops
+       * the alternates during prerendering under `cacheComponents` — see
+       * `get-alternates-metadata.ts`.
+       */
+      canonical: new URL(`/${locale}/blog/${slug}`, getAppUrl()).toString(),
+    },
     openGraph: {
       title: post.title,
       description: post.excerpt,

--- a/src/app/(wids)/[locale]/blog/layout.tsx
+++ b/src/app/(wids)/[locale]/blog/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 
+import { getAlternatesMetadata } from "@/shared/lib/next-intl/get-alternates-metadata";
 import type { Locale } from "@/shared/lib/next-intl/types";
 import { setRequestLocale } from "next-intl/server";
 
@@ -23,7 +24,10 @@ export async function generateMetadata({
     },
   };
 
-  return metadata[locale];
+  return {
+    ...metadata[locale],
+    alternates: getAlternatesMetadata("/blog", locale),
+  };
 }
 
 export default async function Layout({

--- a/src/app/(wids)/[locale]/conference/attendance/layout.tsx
+++ b/src/app/(wids)/[locale]/conference/attendance/layout.tsx
@@ -14,10 +14,14 @@ export async function generateMetadata({
     en: {
       title: "WiDS Guayaquil | Confirm your attendance",
       robots: { index: false, follow: false },
+      // Clears the canonical inherited from the conference layout, which would
+      // otherwise point this page at /conference.
+      alternates: { canonical: null },
     },
     es: {
       title: "WiDS Guayaquil | Confirma tu asistencia",
       robots: { index: false, follow: false },
+      alternates: { canonical: null },
     },
   };
 

--- a/src/app/(wids)/[locale]/conference/layout.tsx
+++ b/src/app/(wids)/[locale]/conference/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { setRequestLocale } from "next-intl/server";
 
+import { getAlternatesMetadata } from "@/shared/lib/next-intl/get-alternates-metadata";
 import type { Locale } from "@/shared/lib/next-intl/types";
 
 export async function generateMetadata({
@@ -23,7 +24,10 @@ export async function generateMetadata({
     },
   };
 
-  return metadata[locale];
+  return {
+    ...metadata[locale],
+    alternates: getAlternatesMetadata("/conference", locale),
+  };
 }
 
 export default async function Layout({

--- a/src/app/(wids)/[locale]/learn/datathon/layout.tsx
+++ b/src/app/(wids)/[locale]/learn/datathon/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { setRequestLocale } from "next-intl/server";
 
+import { getAlternatesMetadata } from "@/shared/lib/next-intl/get-alternates-metadata";
 import type { Locale } from "@/shared/lib/next-intl/types";
 
 export async function generateMetadata({
@@ -23,7 +24,10 @@ export async function generateMetadata({
     },
   };
 
-  return metadata[locale];
+  return {
+    ...metadata[locale],
+    alternates: getAlternatesMetadata("/learn/datathon", locale),
+  };
 }
 
 export default async function Layout({

--- a/src/app/(wids)/[locale]/learn/layout.tsx
+++ b/src/app/(wids)/[locale]/learn/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { setRequestLocale } from "next-intl/server";
 
+import { getAlternatesMetadata } from "@/shared/lib/next-intl/get-alternates-metadata";
 import type { Locale } from "@/shared/lib/next-intl/types";
 
 export async function generateMetadata({
@@ -23,7 +24,10 @@ export async function generateMetadata({
     },
   };
 
-  return metadata[locale];
+  return {
+    ...metadata[locale],
+    alternates: getAlternatesMetadata("/learn", locale),
+  };
 }
 
 export default async function Layout({

--- a/src/app/(wids)/[locale]/learn/nextgen/layout.tsx
+++ b/src/app/(wids)/[locale]/learn/nextgen/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { setRequestLocale } from "next-intl/server";
 
+import { getAlternatesMetadata } from "@/shared/lib/next-intl/get-alternates-metadata";
 import type { Locale } from "@/shared/lib/next-intl/types";
 
 export async function generateMetadata({
@@ -23,7 +24,10 @@ export async function generateMetadata({
     },
   };
 
-  return metadata[locale];
+  return {
+    ...metadata[locale],
+    alternates: getAlternatesMetadata("/learn/nextgen", locale),
+  };
 }
 
 export default async function Layout({

--- a/src/app/(wids)/[locale]/terms-and-conditions/layout.tsx
+++ b/src/app/(wids)/[locale]/terms-and-conditions/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { setRequestLocale } from "next-intl/server";
 
+import { getAlternatesMetadata } from "@/shared/lib/next-intl/get-alternates-metadata";
 import type { Locale } from "@/shared/lib/next-intl/types";
 
 export async function generateMetadata({
@@ -13,13 +14,20 @@ export async function generateMetadata({
   const metadata: Record<Locale, Metadata> = {
     en: {
       title: "WiDS Guayaquil | Terms and Conditions",
+      description:
+        "The terms you accept when registering for a WiDS Guayaquil event, covering attendance, the use of your data, and event photography.",
     },
     es: {
       title: "WiDS Guayaquil | Términos y Condiciones",
+      description:
+        "Los términos que aceptas al registrarte en un evento de WiDS Guayaquil: asistencia, uso de tus datos y fotografía del evento.",
     },
   };
 
-  return metadata[locale];
+  return {
+    ...metadata[locale],
+    alternates: getAlternatesMetadata("/terms-and-conditions", locale),
+  };
 }
 
 export default async function Layout({

--- a/src/shared/lib/next-intl/get-alternates-metadata.ts
+++ b/src/shared/lib/next-intl/get-alternates-metadata.ts
@@ -1,0 +1,60 @@
+import type { Metadata } from "next";
+
+import { routing } from "@/shared/lib/next-intl/routing";
+import type { Locale } from "@/shared/lib/next-intl/types";
+import { getAppUrl } from "@/shared/utils/get-app-url";
+
+type Pathname = keyof typeof routing.pathnames;
+
+/**
+ * Routes with no `[param]` segment, which are the only ones this helper can
+ * resolve on its own. A parameterised route builds its own canonical from the
+ * values behind the params.
+ */
+export type StaticPathname = Exclude<Pathname, `${string}[${string}`>;
+
+/**
+ * Resolves a route to its absolute URL in one locale.
+ *
+ * Deliberately *not* using next-intl's `getPathname`. That helper reaches into
+ * request scope, and under `cacheComponents` it silently drops the whole
+ * `alternates` block during prerendering — measured: with it, `es/about.html`
+ * and `es/blog.html` built without a canonical while `en/about.html` had one,
+ * for no reason visible in the source. Building the path here keeps
+ * `generateMetadata` pure, which also makes it unit-testable.
+ *
+ * The trade is that the locale prefix is applied here rather than derived, so
+ * the assertion below fails loudly if `localePrefix` ever stops being
+ * "always" — the alternative is silently emitting URLs that redirect, which is
+ * how the sitemap broke in #178.
+ */
+function toUrl(pathname: StaticPathname, locale: Locale) {
+  const localized = routing.pathnames[pathname][locale];
+  const path = localized === "/" ? `/${locale}` : `/${locale}${localized}`;
+
+  return new URL(path, getAppUrl()).toString();
+}
+
+/**
+ * Builds the canonical URL and the `hreflang` alternates for a route.
+ *
+ * This carries more weight than it normally would: the `Link` response header
+ * next-intl emits was turned off in #180 to work around a Next.js bug, so
+ * without these tags the sitemap is the only `hreflang` signal the site has.
+ */
+export function getAlternatesMetadata(
+  pathname: StaticPathname,
+  currentLocale: Locale,
+): Metadata["alternates"] {
+  return {
+    canonical: toUrl(pathname, currentLocale),
+    languages: {
+      ...Object.fromEntries(
+        routing.locales.map((locale) => [locale, toUrl(pathname, locale)]),
+      ),
+      // Marks the URL for readers whose language the site does not publish.
+      // That is the default locale; there is no unprefixed URL to point at.
+      "x-default": toUrl(pathname, routing.defaultLocale),
+    },
+  };
+}

--- a/src/shared/tests/get-alternates-metadata.test.ts
+++ b/src/shared/tests/get-alternates-metadata.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import { getAlternatesMetadata } from "@/shared/lib/next-intl/get-alternates-metadata";
+import { routing } from "@/shared/lib/next-intl/routing";
+
+/**
+ * These pin the two things that have already gone wrong once each: emitting a
+ * URL that redirects instead of resolving (#178, where the locale prefix was
+ * omitted and every English alternate landed on the Spanish page), and losing
+ * the alternates entirely (#192, where next-intl's `getPathname` dropped them
+ * during prerendering).
+ */
+describe("getAlternatesMetadata", () => {
+  it("prefixes the locale and uses that locale's pathname", () => {
+    const alternates = getAlternatesMetadata("/about", "en");
+
+    expect(alternates?.canonical).toContain("/en/about");
+    expect(alternates?.languages?.en).toContain("/en/about");
+    expect(alternates?.languages?.es).toContain("/es/nosotros");
+  });
+
+  it("points x-default at the default locale", () => {
+    const alternates = getAlternatesMetadata("/about", "en");
+    const expected = alternates?.languages?.[routing.defaultLocale];
+
+    expect(alternates?.languages?.["x-default"]).toBe(expected);
+  });
+
+  it("keeps the home route from ending in a bare slash", () => {
+    const alternates = getAlternatesMetadata("/", "es");
+
+    // `/es`, not `/es/` — a trailing slash would be a second URL for one page.
+    expect(alternates?.canonical).toMatch(/\/es$/);
+  });
+
+  it("emits an entry for every configured locale, plus x-default", () => {
+    const alternates = getAlternatesMetadata("/conference", "es");
+
+    expect(Object.keys(alternates?.languages ?? {}).sort()).toEqual(
+      [...routing.locales, "x-default"].sort(),
+    );
+  });
+
+  it("never emits a URL that would redirect", () => {
+    // Every unprefixed path redirects to the default locale, so a missing
+    // prefix is the failure this guards against.
+    for (const pathname of ["/", "/about", "/conference", "/blog"] as const) {
+      for (const locale of routing.locales) {
+        const { canonical } = getAlternatesMetadata(pathname, locale) ?? {};
+
+        expect(String(canonical)).toMatch(
+          new RegExp(`^https?://[^/]+/${locale}(/|$)`),
+        );
+      }
+    }
+  });
+});


### PR DESCRIPTION
Closes #192

## What changed

Every indexable route now emits a canonical URL and `hreflang` link tags. Nothing did before.

```html
<link rel="canonical" href="https://wids.espol.edu.ec/en/about"/>
<link rel="alternate" hrefLang="en" href="https://wids.espol.edu.ec/en/about"/>
<link rel="alternate" hrefLang="es" href="https://wids.espol.edu.ec/es/nosotros"/>
<link rel="alternate" hrefLang="x-default" href="https://wids.espol.edu.ec/es/nosotros"/>
```

A shared helper builds the block; the eight indexable route layouts call it. Blog posts get a **canonical only** — slugs are localized, so an hreflang pair needs the other locale's slug and this page has no query that resolves it. A pair built from *this* slug would point at a URL that does not exist, which is worse than emitting nothing.

Also fixed along the way:

- `/conference/attendance` inherited `canonical → /conference` from the conference layout. It is `noindex`, so nothing was indexed wrongly, but the tag was simply incorrect. Now cleared explicitly.
- `/conference/attendance` and `/terms-and-conditions` had a title but no description. Both now have one.

## A correction to my earlier report

I told you nine of ten pages had no `generateMetadata`. **That was wrong** — I had only grepped `page.tsx` files. Every route has a sibling `layout.tsx` with `generateMetadata` supplying a localized title and description, and the coverage there is good. I also said the attendance page needed `noindex`; it already had it.

The real gap was narrower than I described: `alternates`, missing everywhere.

## Why the helper avoids next-intl's `getPathname`

It builds the path from the routing config rather than calling `getPathname`, which reaches into request scope. That keeps `generateMetadata` pure and — more usefully — makes the helper unit-testable without a Next runtime.

The five tests pin the two failures this area has already produced: a URL that redirects instead of resolving (#178, where the locale prefix was omitted and every English alternate landed on the Spanish page) and a missing `x-default`.

## How to verify

Build output is the reliable oracle here:

```bash
pnpm build
for f in .next/server/app/{en,es}/**/*.html; do
  grep -c 'rel="canonical"' "$f"
done
```

All **16** prerendered pages contain one canonical and three `hrefLang` tags. `conference/attendance` correctly contains `noindex` and no canonical.

After deploy, on the real site:

1. View source on `/es/nosotros` and `/en/about` — both should carry canonical plus three alternates, with `es` pointing at `/es/nosotros` and `en` at `/en/about`.
2. Every URL in those tags should return **200 directly**, no redirect.
3. `/conference/attendance?token=…` should show `noindex` and no canonical.

## Risk and rollout

Low. Metadata only — no runtime, routing, data or schema changes. Rollback is a revert.

## Verification done

- All 16 prerendered pages verified to contain canonical + 3 hreflang tags, and the attendance page verified to contain neither (only `noindex`).
- `pnpm lint`, `pnpm typecheck`, `pnpm test` (89 passing, 5 new) and a full `pnpm build` pass.

**One caveat worth reading.** While checking a locally running `pnpm start`, a subset of routes served responses *without* the tags even though their prerendered `.html` files contained them. The cache headers showed those routes being served under the **old** cache profile (`stale-time: 300`) while working routes used the new one (`stale-time: 600`), so the local server was mixing entries across builds. I could not fully explain it, and my local database is empty, which is not representative of production rendering.

I am reporting it rather than glossing over it: **the build artefacts are unambiguously correct, but please confirm step 1 on the preview deployment before merging.** If the same asymmetry shows up there with real data, this needs more work rather than merging.

## Checklist

- [x] Title follows Conventional Commits and matches the work
- [x] Branch is named `type/wids-<issue-number>`
- [x] Linked issue above, so it closes on merge
- [x] Everything is in English
- [x] `pnpm lint`, `pnpm typecheck` and `pnpm test` all pass
- [ ] Preview deployment builds successfully
- [ ] Acceptance criteria on the linked issue are met
