### PR TITLE
refactor(core): unify Payload imports and drop the deprecated image prop

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,3 +143,24 @@ Run these before opening a PR. Use pnpm scripts — never `npx`, which can resol
 | `pnpm typecheck` | `tsc --noEmit`                        |
 | `pnpm test`      | vitest, once, non-watching            |
 | `pnpm build`     | the production build (needs Postgres) |
+
+### When you touch `src/shared/lib/payload/`
+
+Also run:
+
+```bash
+pnpm payload seed
+```
+
+Nothing above covers it. The `bin` scripts declared in `payload.config.ts` —
+`seed` and `queue-attendance-confirmations` — are loaded by the Payload CLI from
+`scriptPath`, outside both the Next bundler and `payload migrate`. A module that
+resolves everywhere else can still fail there, and the failure is silent until
+somebody seeds.
+
+That folder used relative imports with explicit `.ts` extensions for exactly
+this reason: the `@/` alias used to break the seed. It no longer does — both bin
+scripts were verified against Payload 3.88 and Next 16.3.4 — so the folder now
+uses the alias like the rest of the codebase. If the seed ever starts failing to
+resolve a module after a Payload or Next upgrade, this is the first place to
+look.

--- a/src/app/(wids)/[locale]/blog/[slug]/page.tsx
+++ b/src/app/(wids)/[locale]/blog/[slug]/page.tsx
@@ -110,13 +110,19 @@ async function PostArticle({ params }: { params: Params }) {
           </TypographyParagraph>
         </header>
 
+        {/*
+          The cover is this page's LCP element. `priority` was deprecated in
+          Next 16, and the docs recommend this `loading`/`fetchPriority` pair
+          over `preload` unless the image is the only LCP candidate.
+        */}
         {coverImage?.url && (
           <div className="relative aspect-[3/2] w-full overflow-hidden rounded-[20px]">
             <Image
               src={coverImage.url}
               alt={coverImage.alt ?? ""}
               fill
-              priority
+              loading="eager"
+              fetchPriority="high"
               sizes="(max-width: 768px) 100vw, 900px"
               className="object-cover"
             />

--- a/src/shared/lib/payload/collections/ambassadors.ts
+++ b/src/shared/lib/payload/collections/ambassadors.ts
@@ -1,7 +1,7 @@
 import type { CollectionConfig } from "payload";
-import { AMBASSADORS_TAG } from "../../../constants/cache-tags.ts";
-import { createRevalidateHooks } from "../utils/create-revalidate-hooks.ts";
-import { isAdminOrEditor } from "../utils/is-admin-or-editor.ts";
+import { AMBASSADORS_TAG } from "@/shared/constants/cache-tags";
+import { createRevalidateHooks } from "@/shared/lib/payload/utils/create-revalidate-hooks";
+import { isAdminOrEditor } from "@/shared/lib/payload/utils/is-admin-or-editor";
 
 export const Ambassadors: CollectionConfig = {
   slug: "ambassadors",

--- a/src/shared/lib/payload/collections/conference-registrations.ts
+++ b/src/shared/lib/payload/collections/conference-registrations.ts
@@ -4,21 +4,21 @@ import {
   ATTENDANCE_MODE_OPTIONS,
   HEARD_ABOUT_OPTIONS,
   PARTICIPANT_TYPE_OPTIONS,
-} from "../constants/registrations.ts";
+} from "@/shared/lib/payload/constants/registrations";
 import {
   CONFERENCE_REGISTRATION_CONFIRMATION_TASK_SLUG,
   CONFERENCE_REGISTRATION_REMINDER_TASK_SLUG,
-} from "../constants/slugs.ts";
-import { CONFERENCE_REGISTRATION_ERROR_CODES } from "../../../constants/conference-registration-error-codes.ts";
-import { createEventTypeValidationHook } from "../utils/create-event-type-validation.ts";
-import { createRegistrationEmailQueueHook } from "../utils/create-registration-email-queue-hook.ts";
-import { generateAttendanceToken } from "../utils/generate-attendance-token.ts";
-import { isAdminFieldAccess } from "../utils/is-admin-field-access.ts";
-import { isAdminOrEditor } from "../utils/is-admin-or-editor.ts";
-import { validateProfessionalField } from "../utils/validate-professional-field.ts";
-import { validateStudentField } from "../utils/validate-student-field.ts";
-import { validateUniqueEmailPerEvent } from "../utils/validate-unique-email-per-event.ts";
-import { validateUniquePhoneNumberPerEvent } from "../utils/validate-unique-phone-number-per-event.ts";
+} from "@/shared/lib/payload/constants/slugs";
+import { CONFERENCE_REGISTRATION_ERROR_CODES } from "@/shared/constants/conference-registration-error-codes";
+import { createEventTypeValidationHook } from "@/shared/lib/payload/utils/create-event-type-validation";
+import { createRegistrationEmailQueueHook } from "@/shared/lib/payload/utils/create-registration-email-queue-hook";
+import { generateAttendanceToken } from "@/shared/lib/payload/utils/generate-attendance-token";
+import { isAdminFieldAccess } from "@/shared/lib/payload/utils/is-admin-field-access";
+import { isAdminOrEditor } from "@/shared/lib/payload/utils/is-admin-or-editor";
+import { validateProfessionalField } from "@/shared/lib/payload/utils/validate-professional-field";
+import { validateStudentField } from "@/shared/lib/payload/utils/validate-student-field";
+import { validateUniqueEmailPerEvent } from "@/shared/lib/payload/utils/validate-unique-email-per-event";
+import { validateUniquePhoneNumberPerEvent } from "@/shared/lib/payload/utils/validate-unique-phone-number-per-event";
 
 export const ConferenceRegistrations: CollectionConfig = {
   slug: "conference-registrations",

--- a/src/shared/lib/payload/collections/datathon-registrations-individuals.ts
+++ b/src/shared/lib/payload/collections/datathon-registrations-individuals.ts
@@ -6,12 +6,12 @@ import {
   COLLEGE_YEAR_OPTIONS,
   HEARD_ABOUT_OPTIONS,
   SEX_OPTIONS,
-} from "../constants/registrations.ts";
-import { createEventTypeValidationHook } from "../utils/create-event-type-validation.ts";
-import { isAdminOrEditor } from "../utils/is-admin-or-editor.ts";
-import { validateUniqueEmailPerEvent } from "../utils/validate-unique-email-per-event.ts";
-import { validateUniquePhoneNumberPerEvent } from "../utils/validate-unique-phone-number-per-event.ts";
-import { validateUniqueNationalIdPerEvent } from "../utils/validate-unique-national-id-per-event.ts";
+} from "@/shared/lib/payload/constants/registrations";
+import { createEventTypeValidationHook } from "@/shared/lib/payload/utils/create-event-type-validation";
+import { isAdminOrEditor } from "@/shared/lib/payload/utils/is-admin-or-editor";
+import { validateUniqueEmailPerEvent } from "@/shared/lib/payload/utils/validate-unique-email-per-event";
+import { validateUniquePhoneNumberPerEvent } from "@/shared/lib/payload/utils/validate-unique-phone-number-per-event";
+import { validateUniqueNationalIdPerEvent } from "@/shared/lib/payload/utils/validate-unique-national-id-per-event";
 
 export const DatathonRegistrationsIndividuals: CollectionConfig = {
   slug: "datathon-registrations-individuals",

--- a/src/shared/lib/payload/collections/datathon-registrations.ts
+++ b/src/shared/lib/payload/collections/datathon-registrations.ts
@@ -6,19 +6,19 @@ import {
   COLLEGE_YEAR_OPTIONS,
   HEARD_ABOUT_OPTIONS,
   SEX_OPTIONS,
-} from "../constants/registrations.ts";
+} from "@/shared/lib/payload/constants/registrations";
 import {
   DATATHON_REGISTRATION_CONFIRMATION_TASK_SLUG,
   DATATHON_REGISTRATION_REMINDER_TASK_SLUG,
-} from "../constants/slugs.ts";
-import { createEventTypeValidationHook } from "../utils/create-event-type-validation.ts";
-import { createRegistrationEmailQueueHook } from "../utils/create-registration-email-queue-hook.ts";
-import { isAdminOrEditor } from "../utils/is-admin-or-editor.ts";
-import { validateDatathonTeams } from "../utils/validate-datathon-teams.ts";
-import { validateUniqueEmailPerEvent } from "../utils/validate-unique-email-per-event.ts";
-import { validateUniquePhoneNumberPerEvent } from "../utils/validate-unique-phone-number-per-event.ts";
-import { validateUniqueNationalIdPerEvent } from "../utils/validate-unique-national-id-per-event.ts";
-import { validateUniqueTeamNamePerEvent } from "../utils/validate-unique-team-name-per-event.ts";
+} from "@/shared/lib/payload/constants/slugs";
+import { createEventTypeValidationHook } from "@/shared/lib/payload/utils/create-event-type-validation";
+import { createRegistrationEmailQueueHook } from "@/shared/lib/payload/utils/create-registration-email-queue-hook";
+import { isAdminOrEditor } from "@/shared/lib/payload/utils/is-admin-or-editor";
+import { validateDatathonTeams } from "@/shared/lib/payload/utils/validate-datathon-teams";
+import { validateUniqueEmailPerEvent } from "@/shared/lib/payload/utils/validate-unique-email-per-event";
+import { validateUniquePhoneNumberPerEvent } from "@/shared/lib/payload/utils/validate-unique-phone-number-per-event";
+import { validateUniqueNationalIdPerEvent } from "@/shared/lib/payload/utils/validate-unique-national-id-per-event";
+import { validateUniqueTeamNamePerEvent } from "@/shared/lib/payload/utils/validate-unique-team-name-per-event";
 
 export const DatathonRegistrations: CollectionConfig = {
   slug: "datathon-registrations",

--- a/src/shared/lib/payload/collections/editions.ts
+++ b/src/shared/lib/payload/collections/editions.ts
@@ -1,7 +1,7 @@
 import type { CollectionConfig } from "payload";
-import { EDITIONS_TAG } from "../../../constants/cache-tags.ts";
-import { createRevalidateHooks } from "../utils/create-revalidate-hooks.ts";
-import { isAdminOrEditor } from "../utils/is-admin-or-editor.ts";
+import { EDITIONS_TAG } from "@/shared/constants/cache-tags";
+import { createRevalidateHooks } from "@/shared/lib/payload/utils/create-revalidate-hooks";
+import { isAdminOrEditor } from "@/shared/lib/payload/utils/is-admin-or-editor";
 
 export const Editions: CollectionConfig = {
   slug: "editions",

--- a/src/shared/lib/payload/collections/events.ts
+++ b/src/shared/lib/payload/collections/events.ts
@@ -1,8 +1,8 @@
 import type { CollectionConfig } from "payload";
-import { EVENTS_TAG } from "../../../constants/cache-tags.ts";
-import { createRevalidateHooks } from "../utils/create-revalidate-hooks.ts";
-import { EVENT_TYPES } from "../constants/event-types.ts";
-import { isAdminOrEditor } from "../utils/is-admin-or-editor.ts";
+import { EVENTS_TAG } from "@/shared/constants/cache-tags";
+import { createRevalidateHooks } from "@/shared/lib/payload/utils/create-revalidate-hooks";
+import { EVENT_TYPES } from "@/shared/lib/payload/constants/event-types";
+import { isAdminOrEditor } from "@/shared/lib/payload/utils/is-admin-or-editor";
 
 export const Events: CollectionConfig = {
   slug: "events",

--- a/src/shared/lib/payload/collections/media.ts
+++ b/src/shared/lib/payload/collections/media.ts
@@ -1,7 +1,7 @@
 import type { CollectionConfig } from "payload";
-import { MEDIA_TAG } from "../../../constants/cache-tags.ts";
-import { createRevalidateHooks } from "../utils/create-revalidate-hooks.ts";
-import { isAdminOrEditor } from "../utils/is-admin-or-editor.ts";
+import { MEDIA_TAG } from "@/shared/constants/cache-tags";
+import { createRevalidateHooks } from "@/shared/lib/payload/utils/create-revalidate-hooks";
+import { isAdminOrEditor } from "@/shared/lib/payload/utils/is-admin-or-editor";
 
 export const Media: CollectionConfig = {
   slug: "media",

--- a/src/shared/lib/payload/collections/nextgen-registrations.ts
+++ b/src/shared/lib/payload/collections/nextgen-registrations.ts
@@ -1,11 +1,11 @@
 import type { CollectionConfig } from "payload";
 
-import { HEARD_ABOUT_OPTIONS } from "../constants/registrations.ts";
-import { createEventTypeValidationHook } from "../utils/create-event-type-validation.ts";
-import { isAdminOrEditor } from "../utils/is-admin-or-editor.ts";
-import { CONFERENCE_REGISTRATION_ERROR_CODES } from "../../../constants/conference-registration-error-codes.ts";
-import { validateUniqueEmailPerEvent } from "../utils/validate-unique-email-per-event.ts";
-import { validateUniquePhoneNumberPerEvent } from "../utils/validate-unique-phone-number-per-event.ts";
+import { HEARD_ABOUT_OPTIONS } from "@/shared/lib/payload/constants/registrations";
+import { createEventTypeValidationHook } from "@/shared/lib/payload/utils/create-event-type-validation";
+import { isAdminOrEditor } from "@/shared/lib/payload/utils/is-admin-or-editor";
+import { CONFERENCE_REGISTRATION_ERROR_CODES } from "@/shared/constants/conference-registration-error-codes";
+import { validateUniqueEmailPerEvent } from "@/shared/lib/payload/utils/validate-unique-email-per-event";
+import { validateUniquePhoneNumberPerEvent } from "@/shared/lib/payload/utils/validate-unique-phone-number-per-event";
 
 export const NextgenRegistrations: CollectionConfig = {
   slug: "nextgen-registrations",

--- a/src/shared/lib/payload/collections/posts.ts
+++ b/src/shared/lib/payload/collections/posts.ts
@@ -17,9 +17,9 @@ import {
   lexicalEditor,
 } from "@payloadcms/richtext-lexical";
 
-import { POSTS_TAG, postTag } from "../../../constants/cache-tags.ts";
-import { createRevalidateHooks } from "../utils/create-revalidate-hooks.ts";
-import { isAdminOrEditor } from "../utils/is-admin-or-editor.ts";
+import { POSTS_TAG, postTag } from "@/shared/constants/cache-tags";
+import { createRevalidateHooks } from "@/shared/lib/payload/utils/create-revalidate-hooks";
+import { isAdminOrEditor } from "@/shared/lib/payload/utils/is-admin-or-editor";
 
 export const Posts: CollectionConfig = {
   slug: "posts",

--- a/src/shared/lib/payload/collections/schedules.ts
+++ b/src/shared/lib/payload/collections/schedules.ts
@@ -1,8 +1,8 @@
 import type { CollectionConfig, PayloadRequest } from "payload";
-import { SCHEDULES_TAG } from "../../../constants/cache-tags.ts";
-import { createRevalidateHooks } from "../utils/create-revalidate-hooks.ts";
-import { SCHEDULE_TYPES } from "../constants/schedule-types.ts";
-import { isAdminOrEditor } from "../utils/is-admin-or-editor.ts";
+import { SCHEDULES_TAG } from "@/shared/constants/cache-tags";
+import { createRevalidateHooks } from "@/shared/lib/payload/utils/create-revalidate-hooks";
+import { SCHEDULE_TYPES } from "@/shared/lib/payload/constants/schedule-types";
+import { isAdminOrEditor } from "@/shared/lib/payload/utils/is-admin-or-editor";
 
 export const Schedules: CollectionConfig = {
   slug: "schedules",

--- a/src/shared/lib/payload/collections/speakers.ts
+++ b/src/shared/lib/payload/collections/speakers.ts
@@ -1,7 +1,7 @@
 import type { CollectionConfig } from "payload";
-import { SPEAKERS_TAG } from "../../../constants/cache-tags.ts";
-import { createRevalidateHooks } from "../utils/create-revalidate-hooks.ts";
-import { isAdminOrEditor } from "../utils/is-admin-or-editor.ts";
+import { SPEAKERS_TAG } from "@/shared/constants/cache-tags";
+import { createRevalidateHooks } from "@/shared/lib/payload/utils/create-revalidate-hooks";
+import { isAdminOrEditor } from "@/shared/lib/payload/utils/is-admin-or-editor";
 
 export const Speakers: CollectionConfig = {
   slug: "speakers",

--- a/src/shared/lib/payload/collections/sponsors.ts
+++ b/src/shared/lib/payload/collections/sponsors.ts
@@ -1,8 +1,8 @@
 import type { CollectionConfig } from "payload";
-import { SPONSORS_TAG } from "../../../constants/cache-tags.ts";
-import { createRevalidateHooks } from "../utils/create-revalidate-hooks.ts";
-import { SPONSOR_TIERS } from "../constants/sponsor-tiers.ts";
-import { isAdminOrEditor } from "../utils/is-admin-or-editor.ts";
+import { SPONSORS_TAG } from "@/shared/constants/cache-tags";
+import { createRevalidateHooks } from "@/shared/lib/payload/utils/create-revalidate-hooks";
+import { SPONSOR_TIERS } from "@/shared/lib/payload/constants/sponsor-tiers";
+import { isAdminOrEditor } from "@/shared/lib/payload/utils/is-admin-or-editor";
 
 export const Sponsors: CollectionConfig = {
   slug: "sponsors",

--- a/src/shared/lib/payload/collections/users.ts
+++ b/src/shared/lib/payload/collections/users.ts
@@ -1,13 +1,13 @@
 // import { render } from "react-email";
 import type { CollectionConfig } from "payload";
 
-// import ForgotPassword from "../../react-email/forgot-password.tsx";
-// import VerifyEmail from "../../react-email/verify-email.tsx";
-import { checkRole } from "../utils/check-role.ts";
-import { ensureFirstUserIsAdmin } from "../utils/ensure-first-user-is-admin.ts";
-import { isAdmin } from "../utils/is-admin.ts";
-import { isAdminFieldAccess } from "../utils/is-admin-field-access.ts";
-import { isAdminOrSelf } from "../utils/is-admin-or-self.ts";
+// import ForgotPassword from "@/shared/lib/react-email/forgot-password";
+// import VerifyEmail from "@/shared/lib/react-email/verify-email";
+import { checkRole } from "@/shared/lib/payload/utils/check-role";
+import { ensureFirstUserIsAdmin } from "@/shared/lib/payload/utils/ensure-first-user-is-admin";
+import { isAdmin } from "@/shared/lib/payload/utils/is-admin";
+import { isAdminFieldAccess } from "@/shared/lib/payload/utils/is-admin-field-access";
+import { isAdminOrSelf } from "@/shared/lib/payload/utils/is-admin-or-self";
 
 export const Users: CollectionConfig = {
   slug: "users",

--- a/src/shared/lib/payload/globals/terms-and-conditions.ts
+++ b/src/shared/lib/payload/globals/terms-and-conditions.ts
@@ -1,8 +1,8 @@
 import type { GlobalConfig } from "payload";
 
-import { isAdminOrEditor } from "../utils/is-admin-or-editor";
-import { TERMS_AND_CONDITIONS_TAG } from "../../../constants/cache-tags";
-import { revalidateCache } from "../../../utils/revalidate-cache";
+import { isAdminOrEditor } from "@/shared/lib/payload/utils/is-admin-or-editor";
+import { TERMS_AND_CONDITIONS_TAG } from "@/shared/constants/cache-tags";
+import { revalidateCache } from "@/shared/utils/revalidate-cache";
 
 export const TermsAndConditions: GlobalConfig = {
   slug: "terms-and-conditions",

--- a/src/shared/lib/payload/migrations/index.ts
+++ b/src/shared/lib/payload/migrations/index.ts
@@ -1,12 +1,12 @@
-import * as migration_20260414_203346 from "./20260414_203346";
-import * as migration_20260511_032740 from "./20260511_032740";
-import * as migration_20260513_225900 from "./20260513_225900";
-import * as migration_20260521_022131 from "./20260521_022131";
-import * as migration_20260724_020828_add_conference_attendance_confirmation from "./20260724_020828_add_conference_attendance_confirmation";
-import * as migration_20260724_035754_add_attendance_confirmation_job_slug from "./20260724_035754_add_attendance_confirmation_job_slug";
-import * as migration_20260725_012713_add_posts_collection from "./20260725_012713_add_posts_collection";
-import * as migration_20260907_120000_relative_media_urls from "./20260907_120000_relative_media_urls";
-import * as migration_20260908_060000_drop_media_prefix from "./20260908_060000_drop_media_prefix";
+import * as migration_20260414_203346 from "@/shared/lib/payload/migrations/20260414_203346";
+import * as migration_20260511_032740 from "@/shared/lib/payload/migrations/20260511_032740";
+import * as migration_20260513_225900 from "@/shared/lib/payload/migrations/20260513_225900";
+import * as migration_20260521_022131 from "@/shared/lib/payload/migrations/20260521_022131";
+import * as migration_20260724_020828_add_conference_attendance_confirmation from "@/shared/lib/payload/migrations/20260724_020828_add_conference_attendance_confirmation";
+import * as migration_20260724_035754_add_attendance_confirmation_job_slug from "@/shared/lib/payload/migrations/20260724_035754_add_attendance_confirmation_job_slug";
+import * as migration_20260725_012713_add_posts_collection from "@/shared/lib/payload/migrations/20260725_012713_add_posts_collection";
+import * as migration_20260907_120000_relative_media_urls from "@/shared/lib/payload/migrations/20260907_120000_relative_media_urls";
+import * as migration_20260908_060000_drop_media_prefix from "@/shared/lib/payload/migrations/20260908_060000_drop_media_prefix";
 
 export const migrations = [
   {

--- a/src/shared/lib/payload/seed.ts
+++ b/src/shared/lib/payload/seed.ts
@@ -2,7 +2,7 @@ import payloadConfig from "@payload-config";
 // import { readFile } from "node:fs/promises";
 import { basename /* extname, resolve */ } from "node:path";
 import { getPayload, type Payload } from "payload";
-import { getAppUrl } from "../../utils/get-app-url.ts";
+import { getAppUrl } from "@/shared/utils/get-app-url";
 import type {
   Ambassador,
   Edition,
@@ -10,7 +10,7 @@ import type {
   Schedule,
   Speaker,
   Sponsor,
-} from "./types/payload.ts";
+} from "@/shared/lib/payload/types/payload";
 
 // const LOCAL_IMAGE_MIME_TYPES: Record<string, string> = {
 //   ".jpeg": "image/jpeg",

--- a/src/shared/lib/payload/types/event.ts
+++ b/src/shared/lib/payload/types/event.ts
@@ -1,3 +1,3 @@
-import type { EVENT_TYPES } from "../constants/event-types.ts";
+import type { EVENT_TYPES } from "@/shared/lib/payload/constants/event-types";
 
 export type Event = (typeof EVENT_TYPES)[number];

--- a/src/shared/lib/payload/types/registration.ts
+++ b/src/shared/lib/payload/types/registration.ts
@@ -2,7 +2,7 @@ import type {
   ATTENDANCE_MODES,
   HEARD_ABOUT_VALUES,
   PARTICIPANT_TYPES,
-} from "../constants/registrations.ts";
+} from "@/shared/lib/payload/constants/registrations";
 
 export type ParticipantType = (typeof PARTICIPANT_TYPES)[number];
 export type AttendanceMode = (typeof ATTENDANCE_MODES)[number];

--- a/src/shared/lib/payload/types/role.ts
+++ b/src/shared/lib/payload/types/role.ts
@@ -1,3 +1,3 @@
-import type { ROLES } from "../constants/roles.ts";
+import type { ROLES } from "@/shared/lib/payload/constants/roles";
 
 export type Role = (typeof ROLES)[number];

--- a/src/shared/lib/payload/utils/check-role.ts
+++ b/src/shared/lib/payload/utils/check-role.ts
@@ -1,6 +1,6 @@
 import type { TypedUser } from "payload";
 
-import type { Role } from "../types/role.ts";
+import type { Role } from "@/shared/lib/payload/types/role";
 
 export function checkRole(roles: Role[], user: TypedUser | null): boolean {
   if (!user) return false;

--- a/src/shared/lib/payload/utils/create-event-type-validation.ts
+++ b/src/shared/lib/payload/utils/create-event-type-validation.ts
@@ -1,6 +1,6 @@
 import type { CollectionBeforeValidateHook } from "payload";
 
-import type { Event } from "../types/event.ts";
+import type { Event } from "@/shared/lib/payload/types/event";
 
 const extractEventId = (value: unknown): number | null => {
   if (typeof value === "number") {

--- a/src/shared/lib/payload/utils/create-registration-email-queue-hook.ts
+++ b/src/shared/lib/payload/utils/create-registration-email-queue-hook.ts
@@ -1,9 +1,9 @@
 import type { CollectionAfterChangeHook, TypedJobs } from "payload";
 
-import { routing } from "../../next-intl/routing.ts";
-import type { Locale } from "../../next-intl/types.ts";
-import { tryCatch } from "../../../utils/try-catch.ts";
-import { getRelationshipId } from "./get-relationship-id.ts";
+import { routing } from "@/shared/lib/next-intl/routing";
+import type { Locale } from "@/shared/lib/next-intl/types";
+import { tryCatch } from "@/shared/utils/try-catch";
+import { getRelationshipId } from "@/shared/lib/payload/utils/get-relationship-id";
 
 /** The reminder is scheduled a day before the event, plus a second of slack. */
 const ONE_DAY_IN_MILLISECONDS = 24 * 60 * 60 * 1000 + 1000;

--- a/src/shared/lib/payload/utils/create-revalidate-hooks.ts
+++ b/src/shared/lib/payload/utils/create-revalidate-hooks.ts
@@ -3,7 +3,7 @@ import type {
   CollectionAfterDeleteHook,
 } from "payload";
 
-import { revalidateCache } from "../../../utils/revalidate-cache.ts";
+import { revalidateCache } from "@/shared/utils/revalidate-cache";
 
 type Options = {
   /** Names the collection in log messages. */

--- a/src/shared/lib/payload/utils/is-admin-field-access.ts
+++ b/src/shared/lib/payload/utils/is-admin-field-access.ts
@@ -1,6 +1,6 @@
 import type { FieldAccess } from "payload";
 
-import { checkRole } from "../utils/check-role.ts";
+import { checkRole } from "@/shared/lib/payload/utils/check-role";
 
 export const isAdminFieldAccess: FieldAccess = ({ req: { user } }) =>
   checkRole(["admin"], user);

--- a/src/shared/lib/payload/utils/is-admin-or-editor.ts
+++ b/src/shared/lib/payload/utils/is-admin-or-editor.ts
@@ -1,6 +1,6 @@
 import type { Access } from "payload";
 
-import { checkRole } from "../utils/check-role.ts";
+import { checkRole } from "@/shared/lib/payload/utils/check-role";
 
 export const isAdminOrEditor: Access = ({ req: { user } }) =>
   checkRole(["admin", "editor"], user);

--- a/src/shared/lib/payload/utils/is-admin-or-self.ts
+++ b/src/shared/lib/payload/utils/is-admin-or-self.ts
@@ -1,6 +1,6 @@
 import type { Access } from "payload";
 
-import { checkRole } from "../utils/check-role.ts";
+import { checkRole } from "@/shared/lib/payload/utils/check-role";
 
 export const isAdminOrSelf: Access = ({ req: { user } }) => {
   if (!user) return false;

--- a/src/shared/lib/payload/utils/is-admin.ts
+++ b/src/shared/lib/payload/utils/is-admin.ts
@@ -1,6 +1,6 @@
 import type { Access } from "payload";
 
-import { checkRole } from "../utils/check-role.ts";
+import { checkRole } from "@/shared/lib/payload/utils/check-role";
 
 export const isAdmin: Access = ({ req: { user } }) =>
   checkRole(["admin"], user);

--- a/src/shared/lib/payload/utils/validate-datathon-teams.ts
+++ b/src/shared/lib/payload/utils/validate-datathon-teams.ts
@@ -1,6 +1,6 @@
 import type { ArrayFieldValidation } from "payload";
 
-import type { SEX_OPTIONS } from "../constants/registrations.ts";
+import type { SEX_OPTIONS } from "@/shared/lib/payload/constants/registrations";
 
 type DatathonSiblingData = {
   memberCount?: number | null;

--- a/src/shared/lib/payload/utils/validate-unique-email-per-event.ts
+++ b/src/shared/lib/payload/utils/validate-unique-email-per-event.ts
@@ -2,7 +2,7 @@ import type { EmailFieldValidation } from "payload";
 
 import { CONFERENCE_REGISTRATION_ERROR_CODES } from "@/shared/constants/conference-registration-error-codes";
 
-import { createUniquePerEventValidator } from "./create-unique-per-event-validator";
+import { createUniquePerEventValidator } from "@/shared/lib/payload/utils/create-unique-per-event-validator";
 
 export const validateUniqueEmailPerEvent: EmailFieldValidation =
   createUniquePerEventValidator({

--- a/src/shared/lib/payload/utils/validate-unique-national-id-per-event.ts
+++ b/src/shared/lib/payload/utils/validate-unique-national-id-per-event.ts
@@ -2,7 +2,7 @@ import type { TextFieldValidation } from "payload";
 
 import { DATATHON_REGISTRATION_ERROR_CODES } from "@/shared/constants/datathon-registration-error-codes";
 
-import { createUniquePerEventValidator } from "./create-unique-per-event-validator";
+import { createUniquePerEventValidator } from "@/shared/lib/payload/utils/create-unique-per-event-validator";
 
 export const validateUniqueNationalIdPerEvent: TextFieldValidation =
   createUniquePerEventValidator({

--- a/src/shared/lib/payload/utils/validate-unique-phone-number-per-event.ts
+++ b/src/shared/lib/payload/utils/validate-unique-phone-number-per-event.ts
@@ -2,7 +2,7 @@ import type { TextFieldValidation } from "payload";
 
 import { CONFERENCE_REGISTRATION_ERROR_CODES } from "@/shared/constants/conference-registration-error-codes";
 
-import { createUniquePerEventValidator } from "./create-unique-per-event-validator";
+import { createUniquePerEventValidator } from "@/shared/lib/payload/utils/create-unique-per-event-validator";
 
 export const validateUniquePhoneNumberPerEvent: TextFieldValidation =
   createUniquePerEventValidator({

--- a/src/shared/lib/payload/utils/validate-unique-team-name-per-event.ts
+++ b/src/shared/lib/payload/utils/validate-unique-team-name-per-event.ts
@@ -2,7 +2,7 @@ import type { TextFieldValidation } from "payload";
 
 import { DATATHON_REGISTRATION_ERROR_CODES } from "@/shared/constants/datathon-registration-error-codes";
 
-import { createUniquePerEventValidator } from "./create-unique-per-event-validator";
+import { createUniquePerEventValidator } from "@/shared/lib/payload/utils/create-unique-per-event-validator";
 
 export const validateUniqueTeamNamePerEvent: TextFieldValidation =
   createUniquePerEventValidator({


### PR DESCRIPTION
Closes #194

## What changed

**One import dialect under `src/shared/lib/payload`.** `tasks/` used the `@/` alias while `collections/`, `utils/` and `types/` used relative paths with explicit `.ts` extensions. All 150 imports in that tree now use the alias.

**No more deprecated `next/image` prop.** The blog cover used `priority`, deprecated in Next 16.

`payload.config.ts` is untouched — it sits outside `src/` and is the entry point the CLI loads directly, so it is a genuine exception rather than an oversight.

## The relative imports had a reason, and it no longer applies

**This is the important part of the review.** The relative + `.ts` style was not arbitrary: the `@/` alias used to break `pnpm payload seed`. My first pass at this PR missed that, and I verified only `payload migrate:status` and `pnpm build` — neither of which touches the seed.

The seed is loaded by the Payload CLI from `bin.scriptPath` in `payload.config.ts`, **outside both the Next bundler and `payload migrate`**. It is its own module-resolution path, and nothing in CI or the build exercises it.

Re-verified properly on this branch:

```
$ pnpm payload seed
… Uploaded seed media 1..8
… Successfully seeded Payload with admin user …, edition 1, sponsors 1, 2.

$ pnpm payload queue-attendance-confirmations
… prints its usage (exits 1 for missing args, not a module error)

$ pnpm payload migrate:status
… lists all 9 migrations, Ran: Yes
```

All three resolve. The likely reason it changed is #189, which moved Payload 3.87 → 3.88, Next 16.3.0 → 16.3.4 and pnpm 11 → 12. I cannot prove *why*, which is the part worth being careful about: if it is version-dependent, it can regress.

So CONTRIBUTING now carries the safeguard — run the seed when touching that folder, plus a note recording why the relative imports existed, so a future failure is diagnosed rather than rediscovered.

## On the image prop

Next 16's docs:

> "Starting with Next.js 16, the `priority` property has been deprecated in favor of the `preload` property."

and then, about `preload`:

> "In most cases, you should use `loading="eager"` or `fetchPriority="high"` instead of `preload`."
> "When not to use it: when you have multiple images that could be the LCP element depending on the viewport."

So the cover now uses `loading="eager"` + `fetchPriority="high"`, matching what `hero-section.tsx` and `hero-slider.tsx` already do — the slider correctly marks only the first slide eager.

### Correcting my earlier report

I told you only 1 of 17 images had `priority` and that the heroes needed it. **That was a bad reading.** The hero components already use the modern, recommended pair; the single `priority` was the one *deprecated* usage, not the only correct one. Adding `preload` to more images would have worked against the LCP, not for it.

## How to verify

```bash
pnpm payload seed               # the path that used to break — run this one
pnpm payload migrate:status     # CLI resolves the aliased migration index
pnpm build                      # runs payload migrate, then compiles
grep -rn '\bpriority\b' src --include='*.tsx' | grep -v fetchPriority   # empty
grep -rn 'from "\.\.\?/' src/shared/lib/payload | wc -l                 # 0
```

After deploy, the blog cover should still load eagerly — check the network panel shows it fetched at high priority rather than lazily.

## Risk and rollout

Low, but not zero, and concentrated in one place: module resolution fails at runtime, not at typecheck, and the `bin` scripts are covered by neither CI nor `pnpm build`. That is why all three CLI entry points were run directly.

If a future Payload or Next upgrade reintroduces the breakage, the symptom is `pnpm payload seed` failing to resolve a module, and CONTRIBUTING now points at this as the first place to look.

No behaviour changes beyond the image loading hint. Rollback is a revert.

## Verification done

- `pnpm payload seed` runs to completion, uploading 8 media items and seeding the edition and sponsors. This is the path the relative imports existed to protect.
- `pnpm payload queue-attendance-confirmations` loads and prints its usage.
- `pnpm payload migrate:status` lists all nine migrations — the aliased `migrations/index.ts` resolves under the CLI.
- `pnpm build` succeeds, including `payload migrate`.
- `pnpm lint`, `pnpm typecheck`, `pnpm test` (84 passing) pass.
- Zero relative imports and zero `.ts` extensions remain under `src/shared/lib/payload`; `payload.config.ts` shows no diff.

## Checklist

- [x] Title follows Conventional Commits and matches the work
- [x] Branch is named `type/wids-<issue-number>`
- [x] Linked issue above, so it closes on merge
- [x] Everything is in English
- [x] `pnpm lint`, `pnpm typecheck` and `pnpm test` all pass
- [ ] Preview deployment builds successfully
- [x] Acceptance criteria on the linked issue are met
