### PR TITLE
feat(seo): publish Event and Organization structured data

### DIFF
--- a/src/app/(wids)/[locale]/conference/page.tsx
+++ b/src/app/(wids)/[locale]/conference/page.tsx
@@ -15,6 +15,8 @@ import { TypographyParagraph } from "@/shared/components/ui/typography-paragraph
 import type { Locale } from "@/shared/lib/next-intl/types";
 import type { Speaker } from "@/shared/lib/payload/types/payload";
 
+import { JsonLd } from "@/shared/components/json-ld";
+import { getEventJsonLd } from "@/features/landing/utils/get-event-json-ld";
 import { HeroSection } from "@/features/landing/components/hero-section";
 import { Stepper } from "@/features/landing/components/stepper";
 import { PersonCard } from "@/features/landing/components/person-card";
@@ -35,6 +37,10 @@ export default async function Conference({
 
   return (
     <main className="flex flex-col gap-20 px-4 py-20 md:px-4 lg:px-8 xl:px-42">
+      {/* Only when the CMS has an event: an Event block with no date or
+          venue is worse than none. */}
+      {event && <JsonLd data={getEventJsonLd(event)} />}
+
       <HeroSection
         title={t("title")}
         src="/api/media/file/conference-hero.webp"

--- a/src/app/(wids)/[locale]/layout.tsx
+++ b/src/app/(wids)/[locale]/layout.tsx
@@ -3,11 +3,13 @@ import Script from "next/script";
 import { notFound } from "next/navigation";
 import { Barlow, Barlow_Condensed } from "next/font/google";
 import { hasLocale, NextIntlClientProvider } from "next-intl";
-import { setRequestLocale } from "next-intl/server";
+import { getTranslations, setRequestLocale } from "next-intl/server";
 
 import { Toaster } from "@/shared/components/ui/sonner";
 import { Footer } from "@/shared/components/footer";
 import { Header } from "@/shared/components/header";
+import { JsonLd } from "@/shared/components/json-ld";
+import { getOrganizationJsonLd } from "@/shared/lib/seo/get-organization-json-ld";
 import { routing } from "@/shared/lib/next-intl/routing";
 import { UMAMI_TRACKED_DOMAINS } from "@/shared/lib/umami/umami-domains";
 import { cn } from "@/shared/utils/cn";
@@ -63,6 +65,8 @@ export default async function RootLayout({
 
   setRequestLocale(locale);
 
+  const t = await getTranslations("shared.footer");
+
   return (
     <html
       lang={locale}
@@ -81,6 +85,10 @@ export default async function RootLayout({
         />
       </head>
       <body>
+        {/* Site-wide identity: name, logo and the social profiles that let a
+            search engine tie this site to accounts it already knows. */}
+        <JsonLd data={getOrganizationJsonLd(t("description"))} />
+
         <NextIntlClientProvider>
           <Header />
           {children}

--- a/src/app/(wids)/[locale]/learn/datathon/page.tsx
+++ b/src/app/(wids)/[locale]/learn/datathon/page.tsx
@@ -17,6 +17,8 @@ import {
 import type { Locale } from "@/shared/lib/next-intl/types";
 import type { Speaker } from "@/shared/lib/payload/types/payload";
 
+import { JsonLd } from "@/shared/components/json-ld";
+import { getEventJsonLd } from "@/features/landing/utils/get-event-json-ld";
 import { BreadcrumbBanner } from "@/features/landing/components/breadcrumb-banner";
 import { Stepper } from "@/features/landing/components/stepper";
 import { PersonCard } from "@/features/landing/components/person-card";
@@ -37,6 +39,10 @@ export default async function Datathon({
 
   return (
     <main className="flex flex-col gap-20 px-4 pb-20 md:px-4 lg:px-8 xl:px-42">
+      {/* Only when the CMS has an event: an Event block with no date or
+          venue is worse than none. */}
+      {event && <JsonLd data={getEventJsonLd(event)} />}
+
       <BreadcrumbBanner
         title={t("title")}
         backLinkHref="/learn"

--- a/src/app/(wids)/[locale]/learn/nextgen/page.tsx
+++ b/src/app/(wids)/[locale]/learn/nextgen/page.tsx
@@ -15,6 +15,8 @@ import { TypographyParagraph } from "@/shared/components/ui/typography-paragraph
 import type { Locale } from "@/shared/lib/next-intl/types";
 import type { Speaker } from "@/shared/lib/payload/types/payload";
 
+import { JsonLd } from "@/shared/components/json-ld";
+import { getEventJsonLd } from "@/features/landing/utils/get-event-json-ld";
 import { BreadcrumbBanner } from "@/features/landing/components/breadcrumb-banner";
 import { Stepper } from "@/features/landing/components/stepper";
 import { PersonCard } from "@/features/landing/components/person-card";
@@ -34,6 +36,10 @@ export default async function NextGen({
 
   return (
     <main className="flex flex-col gap-20 px-4 pb-20 md:px-4 lg:px-8 xl:px-42">
+      {/* Only when the CMS has an event: an Event block with no date or
+          venue is worse than none. */}
+      {event && <JsonLd data={getEventJsonLd(event)} />}
+
       <BreadcrumbBanner
         title={t("title")}
         backLinkHref="/learn"

--- a/src/features/landing/utils/get-event-json-ld.ts
+++ b/src/features/landing/utils/get-event-json-ld.ts
@@ -1,0 +1,73 @@
+import { APP_NAME } from "@/shared/constants/app";
+import type { Event } from "@/shared/lib/payload/types/payload";
+import { getAppUrl } from "@/shared/utils/get-app-url";
+
+const MILLISECONDS_PER_UNIT: Record<Event["durationUnit"], number> = {
+  minutes: 60_000,
+  hours: 3_600_000,
+  days: 86_400_000,
+};
+
+/**
+ * Derives the end of an event from its start plus the CMS duration.
+ *
+ * Exported for the tests: an off-by-one unit here is invisible on the page but
+ * wrong in every search result that shows the event's time.
+ */
+export function getEventEndDate(event: Event): string {
+  const start = new Date(event.date);
+  const end = new Date(
+    start.getTime() +
+      event.duration * MILLISECONDS_PER_UNIT[event.durationUnit],
+  );
+
+  return end.toISOString();
+}
+
+/**
+ * Maps a CMS event onto schema.org's `Event`.
+ *
+ * Everything comes from data the page has already loaded; nothing extra is
+ * fetched. Optional fields are omitted rather than emitted empty, since a
+ * `location` with no name is worse than no `location` at all.
+ */
+export function getEventJsonLd(event: Event) {
+  const appUrl = getAppUrl();
+
+  const offers = event.registrationStart
+    ? {
+        offers: {
+          "@type": "Offer",
+          availability: "https://schema.org/InStock",
+          price: 0,
+          priceCurrency: "USD",
+          validFrom: new Date(event.registrationStart).toISOString(),
+          ...(event.registrationEnd
+            ? { validThrough: new Date(event.registrationEnd).toISOString() }
+            : {}),
+        },
+      }
+    : {};
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "Event",
+    name: event.title,
+    description: event.description,
+    startDate: new Date(event.date).toISOString(),
+    endDate: getEventEndDate(event),
+    eventStatus: "https://schema.org/EventScheduled",
+    eventAttendanceMode: "https://schema.org/OfflineEventAttendanceMode",
+    location: {
+      "@type": "Place",
+      name: event.location,
+      ...(event.locationUrl ? { url: event.locationUrl } : {}),
+    },
+    organizer: {
+      "@type": "Organization",
+      name: APP_NAME,
+      url: appUrl.toString(),
+    },
+    ...offers,
+  };
+}

--- a/src/shared/components/json-ld.tsx
+++ b/src/shared/components/json-ld.tsx
@@ -1,0 +1,26 @@
+/**
+ * Serialises a structured-data document for embedding in a `<script>`.
+ *
+ * `<` becomes its unicode escape. This is not cosmetic: every value reaching
+ * here comes from the CMS, so without it an editor could type `</script>` into
+ * a title and close the tag from inside the payload. Exported so the escaping
+ * is covered by a test rather than trusted.
+ */
+export function serializeJsonLd(data: Record<string, unknown>): string {
+  return JSON.stringify(data).replace(/</g, "\\u003c");
+}
+
+/**
+ * Renders a structured-data document as `application/ld+json`.
+ *
+ * A native `<script>` rather than `next/script`: JSON-LD is data, not
+ * executable code, and Next's guide says so explicitly.
+ */
+export function JsonLd({ data }: { data: Record<string, unknown> }) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: serializeJsonLd(data) }}
+    />
+  );
+}

--- a/src/shared/lib/seo/get-organization-json-ld.ts
+++ b/src/shared/lib/seo/get-organization-json-ld.ts
@@ -1,0 +1,23 @@
+import { APP_NAME, SOCIAL_LINKS } from "@/shared/constants/app";
+import { getAppUrl } from "@/shared/utils/get-app-url";
+
+/**
+ * The site-wide `Organization` document.
+ *
+ * `sameAs` is what lets a search engine tie this site to the social profiles it
+ * already knows about, so it is built from the same `SOCIAL_LINKS` the footer
+ * renders — one list, no chance of the two drifting.
+ */
+export function getOrganizationJsonLd(description: string) {
+  const appUrl = getAppUrl();
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    name: APP_NAME,
+    url: appUrl.toString(),
+    logo: new URL("/icon.png", appUrl).toString(),
+    description,
+    sameAs: SOCIAL_LINKS.map((link) => link.href),
+  };
+}

--- a/src/shared/tests/get-event-json-ld.test.ts
+++ b/src/shared/tests/get-event-json-ld.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getEventEndDate,
+  getEventJsonLd,
+} from "@/features/landing/utils/get-event-json-ld";
+import type { Event } from "@/shared/lib/payload/types/payload";
+
+const baseEvent = {
+  id: 1,
+  edition: 1,
+  type: "conference",
+  title: "WiDS Guayaquil 2026 | Conference",
+  description: "A conference.",
+  location: "STEM, ESPOL, Guayaquil, Ecuador",
+  date: "2026-07-31T15:00:00.000Z",
+  date_tz: "America/Bogota",
+  duration: 5,
+  durationUnit: "hours",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+  createdAt: "2026-01-01T00:00:00.000Z",
+} as Event;
+
+describe("getEventEndDate", () => {
+  it.each([
+    ["minutes", 90, "2026-07-31T16:30:00.000Z"],
+    ["hours", 5, "2026-07-31T20:00:00.000Z"],
+    ["days", 2, "2026-08-02T15:00:00.000Z"],
+  ] as const)("handles %s", (durationUnit, duration, expected) => {
+    expect(getEventEndDate({ ...baseEvent, duration, durationUnit })).toBe(
+      expected,
+    );
+  });
+});
+
+describe("getEventJsonLd", () => {
+  it("maps the fields schema.org needs", () => {
+    const jsonLd = getEventJsonLd(baseEvent);
+
+    expect(jsonLd["@type"]).toBe("Event");
+    expect(jsonLd.name).toBe(baseEvent.title);
+    expect(jsonLd.startDate).toBe("2026-07-31T15:00:00.000Z");
+    expect(jsonLd.location).toMatchObject({
+      "@type": "Place",
+      name: baseEvent.location,
+    });
+  });
+
+  it("omits the place URL rather than emitting an empty one", () => {
+    const jsonLd = getEventJsonLd(baseEvent);
+
+    expect(jsonLd.location).not.toHaveProperty("url");
+  });
+
+  it("includes the place URL when the CMS has one", () => {
+    const jsonLd = getEventJsonLd({
+      ...baseEvent,
+      locationUrl: "https://maps.example/espol",
+    });
+
+    expect(jsonLd.location).toHaveProperty("url", "https://maps.example/espol");
+  });
+
+  it("omits offers entirely when registration has no start", () => {
+    expect(getEventJsonLd(baseEvent)).not.toHaveProperty("offers");
+  });
+
+  it("maps the registration window onto an offer", () => {
+    const jsonLd = getEventJsonLd({
+      ...baseEvent,
+      registrationStart: "2026-06-01T00:00:00.000Z",
+      registrationEnd: "2026-07-30T00:00:00.000Z",
+    });
+
+    expect(jsonLd.offers).toMatchObject({
+      "@type": "Offer",
+      validFrom: "2026-06-01T00:00:00.000Z",
+      validThrough: "2026-07-30T00:00:00.000Z",
+    });
+  });
+
+  it("emits an open-ended offer when registration has no end", () => {
+    const jsonLd = getEventJsonLd({
+      ...baseEvent,
+      registrationStart: "2026-06-01T00:00:00.000Z",
+    });
+
+    expect(jsonLd.offers).not.toHaveProperty("validThrough");
+  });
+});

--- a/src/shared/tests/serialize-json-ld.test.ts
+++ b/src/shared/tests/serialize-json-ld.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { serializeJsonLd } from "@/shared/components/json-ld";
+
+describe("serializeJsonLd", () => {
+  it("escapes the character that could close the script tag", () => {
+    const output = serializeJsonLd({
+      name: "WiDS </script><script>alert(1)</script>",
+    });
+
+    expect(output).not.toContain("</script>");
+    expect(output).toContain("\\u003c");
+  });
+
+  it("escapes every occurrence, not just the first", () => {
+    const output = serializeJsonLd({ a: "<one>", b: "<two>" });
+
+    expect(output).not.toContain("<");
+  });
+
+  it("survives a round trip, so the escaping stays valid JSON", () => {
+    const data = { name: "A < B", nested: { url: "https://example.test" } };
+
+    // The escape is a JSON string escape, so parsing gives the original back.
+    expect(JSON.parse(serializeJsonLd(data))).toEqual(data);
+  });
+
+  it("leaves ordinary content untouched", () => {
+    const output = serializeJsonLd({ name: "WiDS Guayaquil" });
+
+    expect(output).toBe('{"name":"WiDS Guayaquil"}');
+  });
+});


### PR DESCRIPTION
Closes #196

## What changed

The site published no structured data. It now emits `Organization` on every page and `Event` on the three event pages.

Verified output, parsed back out of the built HTML:

```json
{
  "@context": "https://schema.org", "@type": "Organization",
  "name": "WiDS Guayaquil", "logo": "…/icon.png",
  "description": "Comunidad local de Women in Data Science en Guayaquil: …",
  "sameAs": ["…facebook…", "…instagram…", "…x.com…", "…linkedin…"]
}
```
```json
{
  "@context": "https://schema.org", "@type": "Event",
  "name": "WiDS Guayaquil 2026 | Conferencia",
  "startDate": "2026-07-31T15:00:00.000Z",
  "endDate":   "2026-07-31T20:00:00.000Z",
  "eventStatus": "https://schema.org/EventScheduled",
  "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
  "location": { "@type": "Place", "name": "STEM, ESPOL, Guayaquil, Ecuador" },
  "organizer": { "@type": "Organization", "name": "WiDS Guayaquil", … }
}
```

`sameAs` is built from the same `SOCIAL_LINKS` the footer renders, so the profiles in the markup cannot drift from the ones on the page. Nothing new is fetched — the event pages already load the event.

## The escaping is the security-relevant part

Every value here comes from the CMS. Without escaping, an editor typing `</script>` into an event title closes the tag from inside the payload — a stored XSS. The Next.js guide calls this out, and `serializeJsonLd` is exported specifically so a test covers it rather than the behaviour being trusted:

```ts
serializeJsonLd({ name: "WiDS </script><script>alert(1)</script>" })
// contains no "</script>", contains "<", and still JSON.parse()s to the original
```

## Tests

Nine tests on the mapper, four on the escaping. The mapper ones exist because its errors are invisible on the page but wrong in every search result:

- `endDate` across **all three** duration units the CMS allows — minutes, hours, days
- optional fields omitted rather than emitted empty (`location.url`, `offers`)
- an open-ended registration window produces an offer with no `validThrough`

The `endDate` arithmetic also matched real seeded data end to end: a 5-hour event starting 15:00 produced 20:00.

## How to verify

```bash
pnpm build
# then, from the built HTML:
grep -oE '"@type":"[A-Za-z]+"' .next/server/app/es/conference.html | sort -u
# → "@type":"Event"  "@type":"Organization"  "@type":"Place"
```

After deploy, run the emitted JSON through Google's [Rich Results Test](https://search.google.com/test/rich-results) and the [Schema Markup Validator](https://validator.schema.org/). That is the check that matters — it is the consumer.

## Risk and rollout

Low. Additive markup only; no runtime, routing, data or schema changes. A page whose CMS event is missing emits no `Event` block rather than an empty one.

Rollback is a revert.

## Verification done

- Both blocks extracted from the built HTML and **parsed as JSON**, on `es` and `en`, for conference, datathon and nextgen. Types present: `Organization`, `Event`, `Place`.
- `Organization` confirmed on non-event pages too (`es/about`, `en/about`).
- `pnpm lint`, `pnpm typecheck`, `pnpm test` (102 passing, 13 new) and a production build pass.

### One local observation, resolved

While checking the build output, the Spanish home prerender came out at 61 KB against 121 KB for English, missing the JSON-LD **and** the hero markup. That looked like the same unexplained asymmetry I flagged on #193.

It is not a code problem. Production, running `main` without this change, serves both locales symmetrically — 137 KB and 135 KB, both with the hero present. The difference is my local database, which I seeded partway through this session. Worth recording because it also retroactively explains the caveat I left on #193.

## Checklist

- [x] Title follows Conventional Commits and matches the work
- [x] Branch is named `type/wids-<issue-number>`
- [x] Linked issue above, so it closes on merge
- [x] Everything is in English
- [x] `pnpm lint`, `pnpm typecheck` and `pnpm test` all pass
- [ ] Preview deployment builds successfully
- [ ] Acceptance criteria on the linked issue are met (Rich Results Test pending a deploy)
