### PR TITLE
feat(ux): catch render errors inside the site chrome

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -32,6 +32,16 @@
         "x": "X",
         "linkedin": "LinkedIn"
       }
+    },
+    "not-found": {
+      "title": "Page not found",
+      "description": "The link you followed does not exist, or the content is no longer available.",
+      "cta": "Back to home"
+    },
+    "error": {
+      "title": "Something went wrong",
+      "description": "We could not load this page. You can try again.",
+      "cta": "Try again"
     }
   },
   "features": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -29,6 +29,16 @@
         "x": "X",
         "linkedin": "LinkedIn"
       }
+    },
+    "not-found": {
+      "title": "Página no encontrada",
+      "description": "El enlace que seguiste no existe o el contenido ya no está disponible.",
+      "cta": "Volver al inicio"
+    },
+    "error": {
+      "title": "Algo salió mal",
+      "description": "No pudimos cargar esta página. Puedes intentarlo de nuevo.",
+      "cta": "Intentar de nuevo"
     }
   },
   "features": {

--- a/src/app/(wids)/[locale]/error.tsx
+++ b/src/app/(wids)/[locale]/error.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useEffect } from "react";
+import { useTranslations } from "next-intl";
+
+import { PageMessage } from "@/shared/components/page-message";
+import { Button } from "@/shared/components/ui/button";
+
+/**
+ * Catches render errors in this segment so they land inside the site chrome
+ * rather than on Next's built-in 500 page, which renders its own document
+ * without the site's styles or fonts.
+ *
+ * `retry` rather than `reset`: it re-fetches and re-renders the boundary's
+ * children, where `reset` only clears the error state. Next 16.3 made `retry`
+ * stable and the docs recommend it in most cases.
+ *
+ * `error.message` is deliberately not rendered. For errors thrown on the
+ * server it is a generic digest in production anyway, and in development it can
+ * carry internals that do not belong on screen.
+ */
+export default function Error({
+  error,
+  retry,
+}: {
+  error: Error & { digest?: string };
+  retry: () => void;
+}) {
+  const t = useTranslations("shared.error");
+
+  useEffect(() => {
+    // The digest is what ties this screen to the server-side log entry.
+    console.error(error);
+  }, [error]);
+
+  return (
+    <main>
+      <PageMessage
+        title={t("title")}
+        description={t("description")}
+        action={<Button onClick={retry}>{t("cta")}</Button>}
+      />
+    </main>
+  );
+}

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+/**
+ * Last resort: this only renders when the root layout itself fails, and it
+ * *replaces* that layout.
+ *
+ * So it declares its own `<html>` and `<body>`, and it cannot rely on anything
+ * the app provides — global styles never reach it, which rules out Tailwind
+ * classes and the design system, and the i18n provider is gone, which rules out
+ * translations. Hence inline styles and English-only copy: this screen has to
+ * work when everything else did not.
+ *
+ * `<title>` is set through React rather than the metadata API, which error
+ * boundaries do not support because they are Client Components.
+ */
+export default function GlobalError({
+  error,
+  retry,
+}: {
+  error: Error & { digest?: string };
+  retry: () => void;
+}) {
+  return (
+    <html lang="en">
+      <body
+        style={{
+          alignItems: "center",
+          display: "flex",
+          fontFamily: "system-ui, sans-serif",
+          justifyContent: "center",
+          minHeight: "100vh",
+          margin: 0,
+          padding: "2rem",
+          textAlign: "center",
+        }}
+      >
+        <title>WiDS Guayaquil</title>
+
+        <main style={{ maxWidth: "32rem" }}>
+          <h1 style={{ fontSize: "1.5rem", marginBottom: "0.5rem" }}>
+            Something went wrong
+          </h1>
+
+          <p style={{ color: "#555", marginBottom: "1.5rem" }}>
+            The page could not be loaded. Please try again.
+          </p>
+
+          <button
+            onClick={retry}
+            style={{
+              background: "#111",
+              border: 0,
+              borderRadius: "9999px",
+              color: "#fff",
+              cursor: "pointer",
+              fontSize: "1rem",
+              padding: "0.6rem 1.4rem",
+            }}
+          >
+            Try again
+          </button>
+
+          {error.digest && (
+            <p style={{ color: "#888", fontSize: "0.8rem", marginTop: "2rem" }}>
+              Reference: {error.digest}
+            </p>
+          )}
+        </main>
+      </body>
+    </html>
+  );
+}

--- a/src/shared/components/page-message.tsx
+++ b/src/shared/components/page-message.tsx
@@ -1,0 +1,35 @@
+import type { ReactNode } from "react";
+
+import { TypographyH1 } from "@/shared/components/ui/typography-h1";
+import { TypographyParagraph } from "@/shared/components/ui/typography-paragraph";
+
+type Props = {
+  title: string;
+  description: string;
+  /** The way out: a link home, a retry button, or nothing. */
+  action?: ReactNode;
+};
+
+/**
+ * A centred "something to tell you" block, for empty, missing and error states.
+ *
+ * Deliberately not a `<main>`: it is used both as a whole page (the error
+ * boundary) and inside one (a blog post that does not exist), and nesting
+ * `<main>` elements is invalid. The caller supplies the landmark.
+ *
+ * Mirrors the shape the attendance page already uses for its own not-found
+ * state, so the site has one treatment for this rather than three.
+ */
+export function PageMessage({ title, description, action }: Props) {
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center gap-6 px-4 py-20 text-center">
+      <TypographyH1>{title}</TypographyH1>
+
+      <TypographyParagraph className="text-muted-foreground max-w-110">
+        {description}
+      </TypographyParagraph>
+
+      {action}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #198

## What changed

An error boundary, localized, inside the site chrome — plus the global fallback for when the root layout itself fails.

**This PR is much smaller than the issue proposed.** I wrote `loading.tsx` and `not-found.tsx` too, verified they do nothing in this app, and dropped them rather than ship dead files. Details below.

## What ships

**`[locale]/error.tsx`** — catches render errors in the segment. Before this, a failure bubbled past the layout to Next's built-in 500 page, which renders its own document with none of the site's styles, fonts or chrome.

Uses `retry`, not `reset`. Next 16.3 made `retry` stable and the docs recommend it: it re-fetches and re-renders the boundary's children, where `reset` only clears the error state. `error.message` is not rendered — on the server it is a generic digest in production and can carry internals in development.

**`app/global-error.tsx`** — for a failure in the root layout. It *replaces* that layout, so it declares its own `<html>`/`<body>` and cannot use Tailwind, the design system or translations. Hence inline styles and English copy. It surfaces `error.digest`, which is what ties the screen to the server log.

**`PageMessage`** — the title/description/action shape, mirroring what the attendance page already uses. Deliberately not a `<main>`, so it works as a whole page or inside one without nesting landmarks.

### Verified

Made a page throw, then requested it:

```
/en/about   →  "Something went wrong"   header=1  footer=1
```

The localized screen renders *inside* the site chrome, which is the whole point.

## What I dropped, and why

**`loading.tsx` never renders here.** Every static route is fully prerendered (`○` in the build), so a segment-level fallback has nothing to cover, and the one streaming route — `blog/[slug]` — has its own closer `<Suspense fallback={<PostSkeleton />}>`, which wins. Confirmed by checking the built App Shells: the skeleton I wrote appears in none of them, while `PostSkeleton` does appear in the blog shell (9 `bg-muted`).

**`not-found.tsx` never fires.** An unknown blog slug still renders Next's untranslated default. I tried it at the segment level *and* at the app root; neither is used. This matches what the docs describe:

> "`global-not-found.js` is useful when you can't build a 404 page using a combination of `layout.js` and `not-found.js`. This can happen [when] your root layout is defined using top-level dynamic segments (e.g. `app/[country]/layout.tsx`)"

Our root layout is `(wids)/[locale]/layout.tsx` — exactly that case. The documented answer is `global-not-found.js`, which is experimental and behind a flag, so it belongs in its own change rather than smuggled into this one.

I also tried rendering the not-found inline in the blog page instead, matching the attendance page's pattern. It did not render either, so it is reverted rather than shipped unverified.

## A pre-existing bug found along the way

While testing I created a real blog post locally — **there are none in production, `totalDocs: 0`, so this route has never been exercised** — and found that its response contains **both** the post *and* the string "This page could not be found".

The App Shell for `/[locale]/blog/[slug]` carries Next's default 404 markup, which is then replaced when the content streams in. So a visitor may briefly see 404 text on a perfectly valid post, and a crawler that does not wait for the stream sees it outright.

**This is on `main` already, not caused by this PR** — I stashed everything, rebuilt from `main`, and reproduced it. Filing separately.

## How to verify

1. Temporarily `throw` in a page, run `pnpm build && pnpm start`, and request it. The localized error screen should render with header and footer present.
2. Click the retry button; it should re-render the segment.

## Risk and rollout

Low. Additive — three new files and two translation keys per locale. Nothing existing changes behaviour; the boundaries only engage on failures that currently produce a worse screen.

## Verification done

- Error boundary confirmed rendering inside the chrome on a throwing page.
- `pnpm lint`, `pnpm typecheck`, `pnpm test` (102 passing) and a production build pass.

**Not verified:** `global-error.tsx`, which requires breaking the root layout itself to trigger. It follows the documented shape.

The Spanish route did not show the error screen in local testing, but that is the local prerender artifact established on #197 — production serves both locales symmetrically, local does not, because of my local database state.

## Checklist

- [x] Title follows Conventional Commits and matches the work
- [x] Branch is named `type/wids-<issue-number>`
- [x] Linked issue above, so it closes on merge
- [x] Everything is in English
- [x] `pnpm lint`, `pnpm typecheck` and `pnpm test` all pass
- [ ] Preview deployment builds successfully
- [ ] Acceptance criteria on the linked issue are met — several are not, deliberately; see "What I dropped"
